### PR TITLE
Sync go_checks.yaml with sds-node-configurator

### DIFF
--- a/.github/workflows/go_checks.yaml
+++ b/.github/workflows/go_checks.yaml
@@ -19,7 +19,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run Go lint
-        uses: deckhouse/modules-actions/go_linter@v2
+        uses: deckhouse/modules-actions/go_linter@v12
+        with:
+          go_version: "1.25.9"
 
   go_tests:
     name: Go tests for images
@@ -30,7 +32,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run Go tests
-        uses: deckhouse/modules-actions/go_tests@v2
+        uses: deckhouse/modules-actions/go_tests@v12
+        with:
+          go_version: "1.25.9"
 
   go_test_coverage:
     name: Go test coverage for images
@@ -41,7 +45,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run Go test coverage count
-        uses: deckhouse/modules-actions/go_test_coverage@v2
+        uses: deckhouse/modules-actions/go_test_coverage@v12
+        with:
+          go_version: "1.25.9"
 
   go_modules_check:
     name: Go modules version
@@ -52,4 +58,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run Go modules version check
-        uses: deckhouse/modules-actions/go_modules_check@v2
+        uses: deckhouse/modules-actions/go_modules_check@v12
+        with:
+          go_version: "1.25.9"


### PR DESCRIPTION
## Summary
- Bump `deckhouse/modules-actions` from `v2` to `v12` in all go_checks jobs
- Add `go_version: "1.25.9"` parameter to all actions

Aligns go_checks.yaml with the canonical version from sds-node-configurator.