### PR TITLE
chore(api): bump DefaultCephVersion to v20.2.1 for demo upgrade

### DIFF
--- a/api/v1alpha1/elastic_cluster.go
+++ b/api/v1alpha1/elastic_cluster.go
@@ -503,7 +503,7 @@ const (
 )
 
 // DefaultCephVersion is used when spec.cephVersion is omitted.
-const DefaultCephVersion = CephVersionV1923
+const DefaultCephVersion = CephVersionV2021
 
 // SupportedCephVersions lists every allowed spec.cephVersion value.
 var SupportedCephVersions = []string{CephVersionV1923, CephVersionV2021}

--- a/images/controller/internal/controller/elastic_cluster_controller_test.go
+++ b/images/controller/internal/controller/elastic_cluster_controller_test.go
@@ -99,7 +99,7 @@ var _ = Describe("ElasticClusterReconciler.Reconcile", func() {
 				newBlockDevice("bd-a", "node-a", "100Gi", true, nil),
 				newRookMonSecret("fsid-abc", "admin-key", "mon-key"),
 				newRookMonEndpointsCM("a=10.0.0.1:6789", "a"),
-				newCephClusterUnstructured(ec, "Ready", "v19.2.3", cephImage),
+				newCephClusterUnstructured(ec, "Ready", v1alpha1.DefaultCephVersion, cephImage),
 				&v1alpha1.ElasticClusterCredential{
 					ObjectMeta: metav1.ObjectMeta{Name: testECName},
 					Spec:       v1alpha1.ElasticClusterCredentialSpec{AdminSecret: "admin-key"},

--- a/images/controller/internal/controller/elastic_cluster_upgrade_test.go
+++ b/images/controller/internal/controller/elastic_cluster_upgrade_test.go
@@ -35,21 +35,21 @@ const (
 )
 
 var _ = Describe("probeCephUpgradeState", func() {
-	desiredVersion := v1alpha1.DefaultCephVersion // "v19.2.3"
+	desiredVersion := v1alpha1.DefaultCephVersion // "v20.2.1"
 	desiredImage := newTestCfg().CephImages[v1alpha1.DefaultCephVersion]
 	otherImage := "registry.example.com/ceph:v20.2.1"
 
 	It("returns Done when versions.overall has a single key matching desired", func() {
-		cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", "v19.2.3", desiredImage)
+		cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", v1alpha1.DefaultCephVersion, desiredImage)
 		withCephClusterCephStatus(cc, "HEALTH_OK", "", "", 0, 0, 0, "", nil, map[string]map[string]int32{
-			"overall": {cephVerString1923: 9},
+			"overall": {cephVerString2021: 9},
 		})
 
 		probe := probeCephUpgradeState(cc, desiredImage, desiredVersion)
 
 		Expect(probe.Done).To(BeTrue())
 		Expect(probe.InProgress).To(BeFalse())
-		Expect(probe.Running).To(Equal(cephVerString1923))
+		Expect(probe.Running).To(Equal(cephVerString2021))
 		Expect(probe.Msg).To(ContainSubstring("running ceph version"))
 	})
 
@@ -122,13 +122,13 @@ var _ = Describe("probeCephUpgradeState", func() {
 	It("falls back to status.version.version when versions.overall is absent", func() {
 		// Bootstrap edge case: Rook has not yet populated
 		// status.ceph.versions, so we have to trust status.version.version.
-		cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", "v19.2.3", desiredImage)
+		cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", v1alpha1.DefaultCephVersion, desiredImage)
 
 		probe := probeCephUpgradeState(cc, desiredImage, desiredVersion)
 
 		Expect(probe.Done).To(BeTrue())
 		Expect(probe.InProgress).To(BeFalse())
-		Expect(probe.Running).To(Equal("v19.2.3"))
+		Expect(probe.Running).To(Equal(v1alpha1.DefaultCephVersion))
 	})
 
 	It("falls back to InProgress when versions.overall is absent and version field mismatches", func() {
@@ -175,9 +175,9 @@ var _ = Describe("ensureUpgrade", func() {
 
 	It("returns done when versions.overall converges on desired", func() {
 		cephImage := newTestCfg().CephImages[v1alpha1.DefaultCephVersion]
-		cc := newCephClusterUnstructured(ec, "Ready", "v19.2.3", cephImage)
+		cc := newCephClusterUnstructured(ec, "Ready", v1alpha1.DefaultCephVersion, cephImage)
 		withCephClusterCephStatus(cc, "HEALTH_OK", "", "", 0, 0, 0, "", nil, map[string]map[string]int32{
-			"overall": {cephVerString1923: 9},
+			"overall": {cephVerString2021: 9},
 		})
 		cl := newFakeClient(cc)
 		r = newElasticClusterReconciler(cl)
@@ -187,7 +187,7 @@ var _ = Describe("ensureUpgrade", func() {
 		Expect(done).To(BeTrue())
 		Expect(inProgress).To(BeFalse())
 		Expect(msg).To(ContainSubstring("running ceph version"))
-		Expect(status.cephVersion.Running).To(Equal(cephVerString1923))
+		Expect(status.cephVersion.Running).To(Equal(cephVerString2021))
 		Expect(status.cephVersion.Requested).To(Equal(v1alpha1.DefaultCephVersion))
 	})
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Switches the controller's desired Ceph version from Squid (v19.2.3) to Tentacle (v20.2.1). Both image variants stay packaged in the Helm template, so a cluster currently running v19.2.3 will be picked up by ensureUpgrade and rolled to v20.2.1 (mon -> mgr -> osd -> mds).

Test fixtures that previously hard-coded the running Ceph version to "v19.2.3" now reference v1alpha1.DefaultCephVersion so the ensureUpgrade and end-to-end Reconcile tests keep converging to Ready when the default flips. Generic versionMatches/byVersion fixtures keep using "v19.2.3" intentionally -- they exercise parsing logic, not the FSM defaults.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need to use actual ceph version

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
