### PR TITLE
feat(webhooks): allow sds-object controller to manage Rook object-store CRs

### DIFF
--- a/images/webhooks/handlers/vendorCRValidator.go
+++ b/images/webhooks/handlers/vendorCRValidator.go
@@ -33,6 +33,10 @@ const (
 
 	allowedControllerUser = "system:serviceaccount:d8-sds-elastic:controller"
 	allowedOperatorUser   = "system:serviceaccount:d8-sds-elastic:rook-ceph-system"
+	// allowedObjectUser is the sds-object controller, which manages
+	// CephObjectStore / CephObjectStoreUser for its Heavy profile (S3 / RGW)
+	// on top of an sds-elastic cluster.
+	allowedObjectUser = "system:serviceaccount:d8-sds-object:controller"
 
 	vendorCRDenyMessage = "Direct modifications to Rook Ceph resources are not allowed. " +
 		"Please use ElasticCluster / ElasticStorageClass (storage.deckhouse.io/v1alpha1) to manage the cluster."
@@ -50,7 +54,7 @@ const (
 // not vendor the objectbucket.io CRDs, so there is nothing to guard.
 var vendorAPIGroups = []string{"internal.sdselastic.deckhouse.io"}
 
-var allowedUsers = []string{allowedControllerUser, allowedOperatorUser}
+var allowedUsers = []string{allowedControllerUser, allowedOperatorUser, allowedObjectUser}
 
 func VendorCRValidate(_ context.Context, arReview *model.AdmissionReview, obj metav1.Object) (*kwhvalidating.ValidatorResult, error) {
 	u, ok := obj.(*unstructured.Unstructured)


### PR DESCRIPTION
## What

The `vendor-cr-validation` admission webhook denies every ServiceAccount except sds-elastic's own controller and the Rook operator from creating/modifying Rook CRs (`internal.sdselastic.deckhouse.io`).

The **sds-object** module's `Heavy` profile provisions a Ceph RGW (S3) on top of an sds-elastic cluster by creating `CephObjectStore` / `CephObjectStoreUser` in `d8-sds-elastic`. Its controller SA was blocked, so a Heavy `ObjectStorageCluster` errored with *"Direct modifications to Rook Ceph resources are not allowed"*.

This adds `system:serviceaccount:d8-sds-object:controller` to the webhook allowlist.

## Context

Found during live testing of sds-object Heavy against an sds-elastic cluster. With this change, sds-object can manage the CephObjectStore/User for its S3 buckets while the webhook keeps blocking arbitrary/other SAs.

## Verification
- `go build` + `go test ./handlers/` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Live validation
Deployed to a test cluster (sds-elastic `imageTag=pr40`). With this allowlist change, sds-object's Heavy `ObjectStorageCluster` reaches Ready: the webhook now logs `User system:serviceaccount:d8-sds-object:controller is allowed to manage vendor CR CephObjectStore/...`, Rook brings up `rook-ceph-rgw-*`, the `CephObjectStoreUser` + bucket are created, and an `mc` job reads/writes (`S3 OK`).
