### PR TITLE
chore: set storage subsystem in module.yaml

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -1,5 +1,7 @@
 name: "sds-elastic"
 stage: "Experimental"
+subsystems:
+  - storage
 descriptions:
   en: "Manages distributed block storage on top of the Rook Ceph operator."
   ru: "Управляет распределённым блочным хранилищем на базе оператора Rook Ceph."


### PR DESCRIPTION
## Description
Declare the `storage` subsystem in `module.yaml` by setting `subsystems: [storage]`.

## Why do we need it, and what problem does it solve?
Standardizes module metadata across all storage modules so each one consistently declares the `storage` subsystem. Modules that previously also listed `infrastructure` are normalized to `storage` only.

## What is the expected result?
`module.yaml` contains:
```yaml
subsystems:
  - storage
```
Metadata-only change; no runtime behavior is affected.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
