### PR TITLE
test(e2e): add VolumeSnapshot round-trip and RWX multi-attach specs

### DIFF
--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -1,4 +1,8 @@
 linters-settings:
+  no-cyrillic:
+    exclude-rules:
+      directories:
+        - hack/
   openapi:
     exclude-rules:
       # Vendor Rook CRDs (crds/vendor/*) now live under the

--- a/.github/workflows/translate-changelog.yml
+++ b/.github/workflows/translate-changelog.yml
@@ -2,7 +2,7 @@ name: Translate Changelog and Create PR
 
 on:
   push:
-    # Запуск для всех веток при любом push
+    # Run on push to any branch
 
 jobs:
   translate-and-pr:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,8 +1,9 @@
 # E2E tests for sds-elastic
 
 End-to-end coverage for the documented `ElasticCluster` / `ElasticStorageClass`
-lifecycle: creation + data round-trip, the data-safety deletion guards, and the
-module disable guard (the `ModuleConfig` validating webhook).
+lifecycle: creation + data round-trip, `VolumeSnapshot` snapshot/restore,
+`ReadWriteMany` multi-attach across nodes, the data-safety deletion guards, and
+the module disable guard (the `ModuleConfig` validating webhook).
 
 1. `storage-e2e` brings up a nested cluster from `tests/cluster_config.yml`
    (1 master + 5 storage workers).
@@ -12,7 +13,8 @@ module disable guard (the `ModuleConfig` validating webhook).
    `storage-e2e/pkg/testkit.EnsureElasticOSDBlockDevices`.
 3. A single shared `ElasticCluster` is created (it bootstraps the vendored Rook
    `CephCluster` — ~15-25 min) and the ordered specs exercise create → data
-   round-trip → deletion guards → module disable on top of it.
+   round-trip → snapshots → RWX multi-attach → deletion guards → module disable
+   on top of it.
 4. `AfterSuite` cleans up leftovers and hands the cluster back to `storage-e2e`.
 
 All Elastic/Rook CR provisioning lives in `storage-e2e/pkg/testkit` (the
@@ -32,9 +34,39 @@ Creating an `ElasticCluster` runs a full Rook bootstrap and is far too slow to
 repeat per spec, so the suite uses a **single shared EC** inside one
 `Describe(..., Ordered)`. Spec registration goes through builder functions
 called in explicit order from the root container
-(`createSpecs → moduleDisableBlockedSpec → deleteSpecs → moduleDisableForceSpec
-→ finalManualCleanupSpec`); the EC-destroying specs run last.
-`RandomizeAllSpecs` stays **off**.
+(`createSpecs → snapshotSpecs → rwxSpecs → moduleDisableBlockedSpec →
+deleteSpecs → moduleDisableForceSpec → finalManualCleanupSpec`); the
+EC-destroying specs run last. `RandomizeAllSpecs` stays **off**.
+
+`snapshotSpecs` (`snapshot_test.go`) and `rwxSpecs` (`rwx_test.go`) run between
+create and delete because they need the shared RBD/CephFS `ElasticStorageClass`
+objects Ready. Both are careful to **fully reclaim** every PVC/PV, restore
+PVC/PV and `VolumeSnapshot` they create (default `reclaimPolicy=Delete`), so the
+later delete-guard specs still see only the createSpecs probes bound — a
+leftover RBD image would flip `BoundVolumesExist` into `DataPresentInPool`, and a
+leftover CephFS subvolume would break the `FilesystemNotEmpty` guard.
+
+### Snapshot specs (`snapshot_test.go`)
+
+For each of RBD Filesystem, RBD Block and CephFS Filesystem (CephFS+Block is
+skipped — `cephfs.csi.ceph.com` is Filesystem-only) the suite: writes data
+(several files, or a random prefix of a raw block device) and records a
+checksum; creates a `VolumeSnapshot` (using the `VolumeSnapshotClass` csi-ceph
+auto-creates per `ElasticStorageClass`, named identically to it) and waits for
+`readyToUse`; restores a new PVC from the snapshot and asserts the checksum
+matches; writes new data to the source and asserts the restored copy is
+unchanged (isolation); then deletes the source and proves the restored volume is
+still writable.
+
+### RWX specs (`rwx_test.go`)
+
+For RBD Block and CephFS Filesystem the suite provisions a `ReadWriteMany` PVC,
+schedules two Pods with **required** pod anti-affinity
+(`topologyKey: kubernetes.io/hostname`) so they land on different nodes, asserts
+`spec.nodeName` differs, and proves bidirectional shared access (write from one
+Pod, read back from the other; Block reads use `dd iflag=direct` to bypass the
+reader node's page cache). RBD RWX is Block-only (a shared filesystem on one RBD
+image is unsafe).
 
 ## Supported run mode
 
@@ -123,8 +155,9 @@ Only the nested-cluster mode driven by `storage-e2e` is supported.
 - `E2E_OSD_DISK_SIZE`:
   size of each raw OSD VirtualDisk, defaults to `20Gi`.
 - `E2E_PROBE_IMAGE`:
-  container image (must ship `sh` + `cat`) for the PVC round-trip probe Pods,
-  defaults to `busybox:1.36`.
+  container image for the PVC round-trip / snapshot / RWX probe Pods, defaults
+  to `busybox:1.36`. Must ship `sh`, `cat`, `dd` (with `iflag=direct`/`oflag`
+  support), `sha256sum`, `sync`, `find`, `sort` and `head`.
 - `E2E_KEEP_CLUSTER_ON_FAILURE`:
   when truthy (`true`/`1`/`yes`), and at least one spec failed, the nested
   cluster is **not** torn down in `AfterSuite`, so you can inspect the live

--- a/e2e/tests/e2e_shared_test.go
+++ b/e2e/tests/e2e_shared_test.go
@@ -103,6 +103,10 @@ const (
 	probeContainerName = "probe"
 	probeMountPath     = "/data"
 	probeFilePath      = "/data/probe.txt"
+
+	// probeDevicePath is where a Block-mode PVC is exposed inside the probe
+	// Pod (via volumeDevices) for the snapshot / RWX block specs.
+	probeDevicePath = "/dev/block"
 )
 
 const (
@@ -137,6 +141,12 @@ var (
 	}
 	persistentVolumeGVR = schema.GroupVersionResource{
 		Group: "", Version: "v1", Resource: "persistentvolumes",
+	}
+	volumeSnapshotGVR = schema.GroupVersionResource{
+		Group: "snapshot.storage.k8s.io", Version: "v1", Resource: "volumesnapshots",
+	}
+	volumeSnapshotContentGVR = schema.GroupVersionResource{
+		Group: "snapshot.storage.k8s.io", Version: "v1", Resource: "volumesnapshotcontents",
 	}
 
 	// upstreamRookGVRs are the original ceph.rook.io resources that MUST NOT
@@ -485,6 +495,55 @@ func waitResourceGone(ctx context.Context, gvr schema.GroupVersionResource, ns, 
 			return ctx.Err()
 		}
 	}
+}
+
+// waitPVCGone waits until the PVC and its bound PV are both gone. With the
+// default reclaimPolicy=Delete this proves the csi-ceph external provisioner
+// destroyed the backing RBD image / CephFS subvolume, keeping the pool /
+// filesystem empty for the later delete-guard specs (a lingering image would
+// flip BoundVolumesExist into DataPresentInPool). Best-effort captures the
+// bound PV name before it disappears; if the PVC is already gone and no PV was
+// observed, it returns nil.
+func waitPVCGone(ctx context.Context, pvcName string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var pvName string
+	var pvc corev1.PersistentVolumeClaim
+	if err := suiteK8s.Get(ctx, client.ObjectKey{Namespace: suiteCfg.namespace, Name: pvcName}, &pvc); err == nil {
+		pvName = pvc.Spec.VolumeName
+	}
+	for {
+		var cur corev1.PersistentVolumeClaim
+		errPVC := suiteK8s.Get(ctx, client.ObjectKey{Namespace: suiteCfg.namespace, Name: pvcName}, &cur)
+		if errPVC == nil && pvName == "" {
+			pvName = cur.Spec.VolumeName
+		}
+		if apierrors.IsNotFound(errPVC) {
+			if pvName == "" {
+				return nil
+			}
+			var pv corev1.PersistentVolume
+			errPV := suiteK8s.Get(ctx, client.ObjectKey{Name: pvName}, &pv)
+			if apierrors.IsNotFound(errPV) {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for pvc %s/%s (pv %q) to be reclaimed", suiteCfg.namespace, pvcName, pvName)
+		}
+		if !sleepCtx(ctx, pollInterval) {
+			return ctx.Err()
+		}
+	}
+}
+
+// podNodeName returns spec.nodeName of the given Pod. Used by the RWX specs to
+// assert that two multi-attach consumers really landed on different nodes.
+func podNodeName(ctx context.Context, podName string) (string, error) {
+	var pod corev1.Pod
+	if err := suiteK8s.Get(ctx, client.ObjectKey{Namespace: suiteCfg.namespace, Name: podName}, &pod); err != nil {
+		return "", err
+	}
+	return pod.Spec.NodeName, nil
 }
 
 // --- Rook verifiers --------------------------------------------------------

--- a/e2e/tests/rwx_test.go
+++ b/e2e/tests/rwx_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// rwxAppLabelKey is the pod label the RWX anti-affinity term selects on.
+	rwxAppLabelKey = "app"
+
+	// rwxBlockAlign is the offset/read granularity for the Block RWX marker.
+	// 4096 keeps dd iflag=direct reads aligned on both 512- and 4096-byte
+	// logical-sector devices.
+	rwxBlockAlign = 4096
+
+	// rwxScenarioTimeout bounds a single (ESC, mode) RWX scenario.
+	rwxScenarioTimeout = 20 * time.Minute
+
+	// rwxCrossNodeReadTimeout bounds how long the reader polls for data written
+	// on the other node to become visible.
+	rwxCrossNodeReadTimeout = 90 * time.Second
+)
+
+// rwxSpecs registers the ReadWriteMany (multi-attach) specs: two Pods forced
+// onto different nodes must share a single volume. RBD only supports RWX in
+// Block mode (a shared filesystem on one RBD image is unsafe), CephFS supports
+// RWX in Filesystem mode. Both reclaim everything they create so the later
+// delete-guard specs are unaffected.
+func rwxSpecs() {
+	It("shares an RBD Block ReadWriteMany volume across two Pods on different nodes", func() {
+		runRWXScenario(escRBDName(), corev1.PersistentVolumeBlock, "rwx-rbd-blk")
+	})
+
+	It("shares a CephFS Filesystem ReadWriteMany volume across two Pods on different nodes", func() {
+		runRWXScenario(escCephFSName(), corev1.PersistentVolumeFilesystem, "rwx-fs-fs")
+	})
+}
+
+// runRWXScenario provisions one RWX PVC, schedules two anti-affine Pods on
+// distinct nodes, and proves bidirectional shared access.
+func runRWXScenario(escName string, mode corev1.PersistentVolumeMode, key string) {
+	GinkgoHelper()
+	ctx, cancel := context.WithTimeout(context.Background(), rwxScenarioTimeout)
+	defer cancel()
+
+	size := suiteCfg.pvcSize
+	if mode == corev1.PersistentVolumeBlock {
+		size = snapBlockPVCSize
+	}
+	pvcName := key
+	podA := key + "-a"
+	podB := key + "-b"
+
+	defer func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), resourceGoneTimeout+5*time.Minute)
+		defer ccancel()
+		_ = deletePod(cctx, podA)
+		_ = deletePod(cctx, podB)
+		_ = deletePVCOnly(cctx, pvcName)
+		_ = waitPVCGone(cctx, pvcName, resourceGoneTimeout)
+	}()
+
+	By("Creating a ReadWriteMany PVC")
+	pvc := buildModePVC(pvcName, escName, size, mode, corev1.ReadWriteMany, "")
+	err := suiteK8s.Create(ctx, pvc)
+	Expect(err == nil || apierrors.IsAlreadyExists(err)).
+		To(BeTrue(), "create RWX pvc %s/%s: %v", suiteCfg.namespace, pvcName, err)
+
+	By("Scheduling two Pods with required anti-affinity so they land on different nodes")
+	Expect(createRWXPod(ctx, podA, pvcName, mode, key)).To(Succeed())
+	Expect(createRWXPod(ctx, podB, pvcName, mode, key)).To(Succeed())
+	Expect(waitPVCBound(ctx, pvcName, pvcBindTimeout)).To(Succeed())
+	Expect(waitPodReady(ctx, podA, podReadyTimeout)).To(Succeed())
+	Expect(waitPodReady(ctx, podB, podReadyTimeout)).To(Succeed())
+
+	By("Asserting the two consumers landed on different nodes")
+	nodeA, err := podNodeName(ctx, podA)
+	Expect(err).NotTo(HaveOccurred())
+	nodeB, err := podNodeName(ctx, podB)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(nodeA).NotTo(BeEmpty())
+	Expect(nodeB).NotTo(BeEmpty())
+	Expect(nodeA).NotTo(Equal(nodeB), "RWX consumers must be scheduled on different nodes")
+
+	By("Writing from podA and reading it back from podB")
+	markerAB := key + "-ab"
+	Expect(rwxWrite(ctx, podA, mode, markerAB, 0)).To(Succeed())
+	Eventually(func() (string, error) {
+		return rwxRead(ctx, podB, mode, len(markerAB), 0)
+	}, rwxCrossNodeReadTimeout, pollInterval).Should(Equal(markerAB), "podB should read data written by podA")
+
+	By("Writing from podB and reading it back from podA (reverse direction)")
+	markerBA := key + "-ba"
+	Expect(rwxWrite(ctx, podB, mode, markerBA, 1)).To(Succeed())
+	Eventually(func() (string, error) {
+		return rwxRead(ctx, podA, mode, len(markerBA), 1)
+	}, rwxCrossNodeReadTimeout, pollInterval).Should(Equal(markerBA), "podA should read data written by podB")
+}
+
+// --- RWX pod / IO helpers --------------------------------------------------
+
+// createRWXPod creates a sleeper Pod that mounts the shared PVC and carries the
+// required inter-pod anti-affinity (topology kubernetes.io/hostname) keyed on
+// antiAffinityLabel so the two consumers are placed on different nodes.
+func createRWXPod(ctx context.Context, podName, pvcName string, mode corev1.PersistentVolumeMode, antiAffinityLabel string) error {
+	pod := buildRWXPod(podName, pvcName, mode, antiAffinityLabel)
+	if err := suiteK8s.Create(ctx, pod); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create rwx pod %s/%s: %w", suiteCfg.namespace, podName, err)
+	}
+	return nil
+}
+
+func buildRWXPod(name, pvcName string, mode corev1.PersistentVolumeMode, antiAffinityLabel string) *corev1.Pod {
+	pod := buildSleeperPod(name, pvcName, mode)
+	pod.Labels = map[string]string{rwxAppLabelKey: antiAffinityLabel}
+	pod.Spec.Affinity = &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{rwxAppLabelKey: antiAffinityLabel},
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		},
+	}
+	return pod
+}
+
+// rwxWrite writes marker into the shared volume from podName. slot selects a
+// distinct file (Filesystem) or aligned device region (Block) so the two write
+// directions do not collide.
+func rwxWrite(ctx context.Context, podName string, mode corev1.PersistentVolumeMode, marker string, slot int) error {
+	var script string
+	if mode == corev1.PersistentVolumeBlock {
+		script = fmt.Sprintf(`set -e; printf '%%s' '%s' | dd of=%s bs=%d seek=%d count=1 conv=fsync,notrunc 2>/dev/null; sync`,
+			marker, probeDevicePath, rwxBlockAlign, slot)
+	} else {
+		script = fmt.Sprintf(`set -e; printf '%%s' '%s' > %s/shared%d.txt; sync`, marker, probeMountPath, slot)
+	}
+	_, err := execSh(ctx, podName, script)
+	return err
+}
+
+// rwxRead reads back the marker from podName. Block reads use iflag=direct to
+// bypass the reader node's page cache and go straight to the OSDs; the aligned
+// block is captured via command substitution (which drops the trailing NUL
+// padding) so no SIGPIPE is raised.
+func rwxRead(ctx context.Context, podName string, mode corev1.PersistentVolumeMode, length, slot int) (string, error) {
+	var script string
+	if mode == corev1.PersistentVolumeBlock {
+		script = fmt.Sprintf(`blk=$(dd if=%s bs=%d skip=%d count=1 iflag=direct 2>/dev/null); printf '%%s' "$blk" | head -c %d`,
+			probeDevicePath, rwxBlockAlign, slot, length)
+	} else {
+		script = fmt.Sprintf(`cat %s/shared%d.txt 2>/dev/null`, probeMountPath, slot)
+	}
+	out, err := execSh(ctx, podName, script)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// --- generic delete helpers (shared PVC, so pods/PVC deleted separately) ----
+
+func deletePod(ctx context.Context, podName string) error {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: suiteCfg.namespace, Name: podName}}
+	if err := suiteK8s.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete pod %s/%s: %w", suiteCfg.namespace, podName, err)
+	}
+	return waitPodGone(ctx, podName, podReadyTimeout)
+}
+
+func deletePVCOnly(ctx context.Context, pvcName string) error {
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Namespace: suiteCfg.namespace, Name: pvcName}}
+	if err := suiteK8s.Delete(ctx, pvc); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete pvc %s/%s: %w", suiteCfg.namespace, pvcName, err)
+	}
+	return nil
+}

--- a/e2e/tests/sds_elastic_suite_test.go
+++ b/e2e/tests/sds_elastic_suite_test.go
@@ -92,6 +92,8 @@ var _ = Describe("sds-elastic e2e", Ordered, ContinueOnFailure, func() {
 	})
 
 	createSpecs()              // create_test.go: EC + RBD/CephFS/HR ESC + data round-trip + no-leak
+	snapshotSpecs()            // snapshot_test.go: VolumeSnapshot round-trip (RBD FS/Block, CephFS FS)
+	rwxSpecs()                 // rwx_test.go: ReadWriteMany multi-attach across nodes (RBD Block, CephFS FS)
 	moduleDisableBlockedSpec() // module_disable_test.go: disable denied while EC exists
 	deleteSpecs()              // delete_test.go: ESC/EC deletion guards (data safety)
 	moduleDisableForceSpec()   // module_disable_test.go: bare EC -> force-disable -> module uninstalled

--- a/e2e/tests/snapshot_test.go
+++ b/e2e/tests/snapshot_test.go
@@ -1,0 +1,435 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	storagekube "github.com/deckhouse/storage-e2e/pkg/kubernetes"
+)
+
+const (
+	// snapBlockPVCSize is the size of Block-mode PVCs in the snapshot / RWX
+	// specs. Kept small so a whole-device sha256 (read end to end) stays fast;
+	// Filesystem-mode PVCs use suiteCfg.pvcSize instead.
+	snapBlockPVCSize = "256Mi"
+
+	// snapBlockWriteMiB is how many MiB of random data we write into a Block
+	// volume before snapshotting. Must be < snapBlockPVCSize so dd never hits
+	// ENOSPC; the rest of the device reads back as deterministic zeros, so a
+	// whole-device checksum is still stable.
+	snapBlockWriteMiB = 200
+
+	// snapFileCount is how many files the Filesystem scenario writes.
+	snapFileCount = 5
+
+	// snapshotReadyTimeout bounds the wait for a VolumeSnapshot to report
+	// status.readyToUse=true.
+	snapshotReadyTimeout = 5 * time.Minute
+
+	// snapScenarioTimeout bounds a single (ESC, mode) snapshot scenario.
+	snapScenarioTimeout = 30 * time.Minute
+)
+
+// snapshotSpecs registers the VolumeSnapshot round-trip specs on the shared
+// RBD / CephFS ElasticStorageClasses created by createSpecs(). Each spec runs
+// the full write -> checksum -> snapshot -> restore -> verify -> isolate ->
+// delete-source -> write-restored flow and then fully reclaims everything it
+// created (PVC+PV, restore PVC+PV, VolumeSnapshot + content) so the later
+// delete-guard specs see only the createSpecs() probes still bound.
+//
+// CephFS+Block is intentionally absent: cephfs.csi.ceph.com is Filesystem-only.
+func snapshotSpecs() {
+	It("snapshots an RBD Filesystem volume, restores it, and verifies integrity, isolation and writability", func() {
+		runSnapshotScenario(escRBDName(), corev1.PersistentVolumeFilesystem, "snap-rbd-fs")
+	})
+
+	It("snapshots an RBD Block volume, restores it, and verifies integrity, isolation and writability", func() {
+		runSnapshotScenario(escRBDName(), corev1.PersistentVolumeBlock, "snap-rbd-blk")
+	})
+
+	It("snapshots a CephFS Filesystem volume, restores it, and verifies integrity, isolation and writability", func() {
+		runSnapshotScenario(escCephFSName(), corev1.PersistentVolumeFilesystem, "snap-fs-fs")
+	})
+}
+
+// runSnapshotScenario implements the 7-step snapshot flow for one ESC +
+// volumeMode combination.
+func runSnapshotScenario(escName string, mode corev1.PersistentVolumeMode, key string) {
+	GinkgoHelper()
+	ctx, cancel := context.WithTimeout(context.Background(), snapScenarioTimeout)
+	defer cancel()
+
+	size := suiteCfg.pvcSize
+	if mode == corev1.PersistentVolumeBlock {
+		size = snapBlockPVCSize
+	}
+
+	origPVC := key + "-orig"
+	origPod := key + "-orig"
+	restorePVC := key + "-restore"
+	restorePod := key + "-restore"
+	snapName := key
+
+	defer func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), resourceGoneTimeout+10*time.Minute)
+		defer ccancel()
+		_ = deleteProbe(cctx, restorePVC, restorePod)
+		_ = deleteProbe(cctx, origPVC, origPod)
+		_ = deleteVolumeSnapshot(cctx, snapName)
+		_ = waitPVCGone(cctx, restorePVC, resourceGoneTimeout)
+		_ = waitPVCGone(cctx, origPVC, resourceGoneTimeout)
+		_ = waitSnapshotGone(cctx, snapName, resourceGoneTimeout)
+		_ = waitSnapshotContentGone(cctx, snapName, resourceGoneTimeout)
+	}()
+
+	By("Creating the original PVC + Pod and writing data")
+	Expect(createSleeperPodWithPVC(ctx, escName, origPVC, origPod, mode, size, "")).
+		To(Succeed(), "original %s PVC+Pod should bind and become Ready", key)
+	Expect(writeSnapshotData(ctx, origPod, mode)).To(Succeed(), "writing data to the source volume")
+	sumOrig, err := checksumData(ctx, origPod, mode)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(sumOrig).NotTo(BeEmpty(), "source checksum must be non-empty")
+
+	By("Creating a VolumeSnapshot and waiting for readyToUse")
+	Expect(createVolumeSnapshot(ctx, snapName, origPVC, escName)).To(Succeed())
+	restoreSize, err := waitSnapshotReady(ctx, snapName, snapshotReadyTimeout)
+	Expect(err).NotTo(HaveOccurred())
+	if strings.TrimSpace(restoreSize) == "" {
+		restoreSize = size
+	}
+
+	By("Restoring a new PVC from the snapshot and asserting the checksum matches the source")
+	Expect(createSleeperPodWithPVC(ctx, escName, restorePVC, restorePod, mode, restoreSize, snapName)).
+		To(Succeed(), "restored %s PVC+Pod should bind and become Ready", key)
+	sumRestored, err := checksumData(ctx, restorePod, mode)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(sumRestored).To(Equal(sumOrig), "restored volume must match the source at snapshot time")
+
+	By("Writing new data to the ORIGINAL and asserting the RESTORED copy is unchanged (isolation)")
+	Expect(mutateSnapshotData(ctx, origPod, mode)).To(Succeed())
+	sumRestoredAfter, err := checksumData(ctx, restorePod, mode)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(sumRestoredAfter).To(Equal(sumOrig), "restored volume must stay isolated from writes to the source")
+
+	By("Deleting the original volume, then writing to the RESTORED volume to prove it is writable")
+	Expect(deleteProbe(ctx, origPVC, origPod)).To(Succeed())
+	Expect(waitPVCGone(ctx, origPVC, resourceGoneTimeout)).To(Succeed())
+	Expect(verifyWritable(ctx, restorePod, mode)).To(Succeed(), "restored volume must remain writable after the source is gone")
+}
+
+// --- PVC / Pod builders (Filesystem + Block) -------------------------------
+
+// createSleeperPodWithPVC provisions a PVC (optionally restored from a
+// snapshot) in the requested volumeMode and a long-lived Pod that mounts it
+// (Filesystem: at probeMountPath; Block: as a raw device at probeDevicePath),
+// then waits for the PVC to Bind and the Pod to be Ready. Idempotent against
+// AlreadyExists.
+func createSleeperPodWithPVC(ctx context.Context, scName, pvcName, podName string, mode corev1.PersistentVolumeMode, size, snapshotSource string) error {
+	pvc := buildModePVC(pvcName, scName, size, mode, corev1.ReadWriteOnce, snapshotSource)
+	if err := suiteK8s.Create(ctx, pvc); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create pvc %s/%s: %w", suiteCfg.namespace, pvcName, err)
+	}
+
+	pod := buildSleeperPod(podName, pvcName, mode)
+	if err := suiteK8s.Create(ctx, pod); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create pod %s/%s: %w", suiteCfg.namespace, podName, err)
+	}
+
+	if err := waitPVCBound(ctx, pvcName, pvcBindTimeout); err != nil {
+		return err
+	}
+	return waitPodReady(ctx, podName, podReadyTimeout)
+}
+
+// buildModePVC renders a PVC with an explicit volumeMode and accessMode. When
+// snapshotSource is non-empty the PVC is provisioned from that VolumeSnapshot.
+func buildModePVC(name, scName, size string, mode corev1.PersistentVolumeMode, accessMode corev1.PersistentVolumeAccessMode, snapshotSource string) *corev1.PersistentVolumeClaim {
+	sc := scName
+	vm := mode
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: suiteCfg.namespace,
+			Name:      name,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{accessMode},
+			StorageClassName: &sc,
+			VolumeMode:       &vm,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse(size),
+				},
+			},
+		},
+	}
+	if snapshotSource != "" {
+		apiGroup := "snapshot.storage.k8s.io"
+		pvc.Spec.DataSource = &corev1.TypedLocalObjectReference{
+			APIGroup: &apiGroup,
+			Kind:     "VolumeSnapshot",
+			Name:     snapshotSource,
+		}
+	}
+	return pvc
+}
+
+// buildSleeperPod renders a Pod that just sleeps, exposing the PVC either as a
+// mounted filesystem (probeMountPath) or a raw block device (probeDevicePath)
+// depending on mode. Tests drive I/O by exec-ing into it.
+func buildSleeperPod(name, pvcName string, mode corev1.PersistentVolumeMode) *corev1.Pod {
+	container := corev1.Container{
+		Name:    probeContainerName,
+		Image:   suiteCfg.probeImage,
+		Command: []string{"sh", "-c", "sleep 360000"},
+	}
+	if mode == corev1.PersistentVolumeBlock {
+		container.VolumeDevices = []corev1.VolumeDevice{{Name: "data", DevicePath: probeDevicePath}}
+	} else {
+		container.VolumeMounts = []corev1.VolumeMount{{Name: "data", MountPath: probeMountPath}}
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: suiteCfg.namespace,
+			Name:      name,
+			Labels:    map[string]string{"app": "sds-elastic-e2e-probe"},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers:    []corev1.Container{container},
+			Volumes: []corev1.Volume{
+				{
+					Name: "data",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvcName,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// --- data write / checksum helpers -----------------------------------------
+
+// execSh runs `sh -c script` inside the probe container and returns stdout,
+// folding a transport error or any stderr output into the returned error.
+func execSh(ctx context.Context, podName, script string) (string, error) {
+	stdout, stderr, err := storagekube.ExecInPod(ctx, suiteRestCfg, suiteCfg.namespace, podName, probeContainerName, []string{"sh", "-c", script})
+	if err != nil {
+		return stdout, fmt.Errorf("exec in %s/%s: %w", suiteCfg.namespace, podName, err)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		return stdout, fmt.Errorf("exec in %s/%s reported stderr: %s", suiteCfg.namespace, podName, stderr)
+	}
+	return stdout, nil
+}
+
+// writeSnapshotData populates the source volume: several random files for a
+// filesystem, or a fixed prefix of random data for a block device. Data is
+// fsync'd and a final sync issued so the subsequent snapshot is consistent.
+func writeSnapshotData(ctx context.Context, podName string, mode corev1.PersistentVolumeMode) error {
+	var script string
+	if mode == corev1.PersistentVolumeBlock {
+		script = fmt.Sprintf(`set -e; dd if=/dev/urandom of=%s bs=1M count=%d conv=fsync 2>/dev/null; sync`,
+			probeDevicePath, snapBlockWriteMiB)
+	} else {
+		script = fmt.Sprintf(`set -e; for i in %s; do dd if=/dev/urandom of=%s/file$i bs=1024 count=1024 conv=fsync 2>/dev/null; done; sync`,
+			fileIdxList(), probeMountPath)
+	}
+	_, err := execSh(ctx, podName, script)
+	return err
+}
+
+// checksumData returns a stable checksum of the volume contents: a whole-device
+// sha256 for Block, or an aggregate sha256 over the sorted file set for
+// Filesystem.
+func checksumData(ctx context.Context, podName string, mode corev1.PersistentVolumeMode) (string, error) {
+	var script string
+	if mode == corev1.PersistentVolumeBlock {
+		script = fmt.Sprintf(`sha256sum %s | awk '{print $1}'`, probeDevicePath)
+	} else {
+		script = fmt.Sprintf(`find %s -type f | sort | xargs sha256sum | sha256sum | awk '{print $1}'`, probeMountPath)
+	}
+	out, err := execSh(ctx, podName, script)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// mutateSnapshotData writes NEW data into the source volume so we can prove the
+// restored copy is isolated: an extra file (Filesystem) or an overwritten
+// region (Block). It never touches the file set / device region a restored
+// volume would carry from the snapshot.
+func mutateSnapshotData(ctx context.Context, podName string, mode corev1.PersistentVolumeMode) error {
+	var script string
+	if mode == corev1.PersistentVolumeBlock {
+		script = fmt.Sprintf(`set -e; dd if=/dev/urandom of=%s bs=1M count=10 conv=fsync,notrunc 2>/dev/null; sync`, probeDevicePath)
+	} else {
+		script = fmt.Sprintf(`set -e; dd if=/dev/urandom of=%s/mutation.bin bs=1024 count=256 conv=fsync 2>/dev/null; sync`, probeMountPath)
+	}
+	_, err := execSh(ctx, podName, script)
+	return err
+}
+
+// verifyWritable writes a marker into the volume and reads it back, proving the
+// restored volume accepts writes after the source is deleted.
+func verifyWritable(ctx context.Context, podName string, mode corev1.PersistentVolumeMode) error {
+	const marker = "sds-elastic-e2e-writable"
+	var script string
+	if mode == corev1.PersistentVolumeBlock {
+		script = fmt.Sprintf(`set -e
+marker='%s'
+len=${#marker}
+printf '%%s' "$marker" | dd of=%s bs=1 seek=512 conv=fsync,notrunc 2>/dev/null
+sync
+got=$(dd if=%s bs=1 skip=512 count=$len 2>/dev/null)
+[ "$got" = "$marker" ] || { echo "block write verify mismatch got=[$got] want=[$marker]" >&2; exit 1; }`,
+			marker, probeDevicePath, probeDevicePath)
+	} else {
+		script = fmt.Sprintf(`set -e
+marker='%s'
+printf '%%s' "$marker" > %s/afterdelete.txt
+sync
+got=$(cat %s/afterdelete.txt)
+[ "$got" = "$marker" ] || { echo "fs write verify mismatch got=[$got] want=[$marker]" >&2; exit 1; }`,
+			marker, probeMountPath, probeMountPath)
+	}
+	_, err := execSh(ctx, podName, script)
+	return err
+}
+
+// fileIdxList returns "1 2 3 ... snapFileCount" for the write loop.
+func fileIdxList() string {
+	ids := make([]string, 0, snapFileCount)
+	for i := 1; i <= snapFileCount; i++ {
+		ids = append(ids, fmt.Sprintf("%d", i))
+	}
+	return strings.Join(ids, " ")
+}
+
+// --- VolumeSnapshot helpers ------------------------------------------------
+
+// createVolumeSnapshot creates a VolumeSnapshot of pvcName using the
+// csi-ceph-managed VolumeSnapshotClass (named identically to the ESC /
+// CephStorageClass). Idempotent against AlreadyExists.
+func createVolumeSnapshot(ctx context.Context, name, pvcName, vscName string) error {
+	snap := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "snapshot.storage.k8s.io/v1",
+			"kind":       "VolumeSnapshot",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": suiteCfg.namespace,
+			},
+			"spec": map[string]interface{}{
+				"volumeSnapshotClassName": vscName,
+				"source": map[string]interface{}{
+					"persistentVolumeClaimName": pvcName,
+				},
+			},
+		},
+	}
+	_, err := suiteDyn.Resource(volumeSnapshotGVR).Namespace(suiteCfg.namespace).Create(ctx, snap, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create VolumeSnapshot %s/%s: %w", suiteCfg.namespace, name, err)
+	}
+	return nil
+}
+
+// waitSnapshotReady blocks until the VolumeSnapshot reports
+// status.readyToUse=true and returns its status.restoreSize (may be empty).
+func waitSnapshotReady(ctx context.Context, name string, timeout time.Duration) (string, error) {
+	deadline := time.Now().Add(timeout)
+	var last string
+	for {
+		obj, err := suiteDyn.Resource(volumeSnapshotGVR).Namespace(suiteCfg.namespace).Get(ctx, name, metav1.GetOptions{})
+		if err == nil {
+			ready, found, _ := unstructured.NestedBool(obj.Object, "status", "readyToUse")
+			if found && ready {
+				restoreSize, _, _ := unstructured.NestedString(obj.Object, "status", "restoreSize")
+				return restoreSize, nil
+			}
+			last = fmt.Sprintf("readyToUse found=%v value=%v", found, ready)
+		} else {
+			last = err.Error()
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("timeout waiting for VolumeSnapshot %s/%s to be readyToUse; last: %s", suiteCfg.namespace, name, last)
+		}
+		if !sleepCtx(ctx, pollInterval) {
+			return "", ctx.Err()
+		}
+	}
+}
+
+// deleteVolumeSnapshot removes a VolumeSnapshot. Idempotent (NotFound ignored).
+func deleteVolumeSnapshot(ctx context.Context, name string) error {
+	err := suiteDyn.Resource(volumeSnapshotGVR).Namespace(suiteCfg.namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete VolumeSnapshot %s/%s: %w", suiteCfg.namespace, name, err)
+	}
+	return nil
+}
+
+// waitSnapshotGone polls until the VolumeSnapshot GET returns NotFound.
+func waitSnapshotGone(ctx context.Context, name string, timeout time.Duration) error {
+	return waitResourceGone(ctx, volumeSnapshotGVR, suiteCfg.namespace, name, timeout)
+}
+
+// waitSnapshotContentGone waits until no VolumeSnapshotContent references the
+// named snapshot, proving the backing Ceph snapshot was reclaimed (so the pool
+// / filesystem is empty again for the delete-guard specs).
+func waitSnapshotContentGone(ctx context.Context, snapName string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		list, err := suiteDyn.Resource(volumeSnapshotContentGVR).List(ctx, metav1.ListOptions{})
+		if err == nil {
+			found := false
+			for i := range list.Items {
+				refName, _, _ := unstructured.NestedString(list.Items[i].Object, "spec", "volumeSnapshotRef", "name")
+				if refName == snapName {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for VolumeSnapshotContent of %s/%s to be gone", suiteCfg.namespace, snapName)
+		}
+		if !sleepCtx(ctx, pollInterval) {
+			return ctx.Err()
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Extends the sds-elastic e2e suite with two new families of specs, registered in
the shared `Ordered` container between `createSpecs` and the delete-guard specs
(so they run against the already-Ready RBD/CephFS `ElasticStorageClass` objects):

- **VolumeSnapshot round-trip** (`e2e/tests/snapshot_test.go`) for RBD
  Filesystem, RBD Block and CephFS Filesystem (CephFS+Block is skipped —
  `cephfs.csi.ceph.com` is Filesystem-only). Each spec runs the full flow:
  write data → checksum → create `VolumeSnapshot` (using the
  `VolumeSnapshotClass` csi-ceph auto-creates per ESC) → restore a PVC from the
  snapshot and assert the checksum matches → write new data to the source and
  assert the restored copy is unchanged (isolation) → delete the source and
  prove the restored volume is still writable.
- **RWX multi-attach** (`e2e/tests/rwx_test.go`) for RBD Block and CephFS
  Filesystem: a `ReadWriteMany` PVC is mounted by two Pods pinned to different
  nodes via required pod anti-affinity; the specs assert `spec.nodeName` differs
  and verify bidirectional shared access (Block reads use `dd iflag=direct` to
  bypass the reader node's page cache). RBD RWX is Block-only by design.

Both families fully reclaim everything they create (PVC/PV, restore PVC/PV,
`VolumeSnapshot` + `VolumeSnapshotContent`) before returning, so the later
delete-guard specs still observe only the createSpecs probes bound — a leftover
RBD image would flip `BoundVolumesExist` into `DataPresentInPool`, and a
leftover CephFS subvolume would break the `FilesystemNotEmpty` guard.

Supporting changes:
- `e2e/tests/e2e_shared_test.go`: `volumeSnapshotGVR` / `volumeSnapshotContentGVR`
  GVRs, `probeDevicePath` const, and the `waitPVCGone` / `podNodeName` helpers.
- `e2e/tests/sds_elastic_suite_test.go`: register `snapshotSpecs()` and
  `rwxSpecs()` in dependency order.
- `e2e/README.md`: document the new specs, their ordered placement, and the
  extended probe-image tool requirements (`dd` with `iflag/oflag=direct`,
  `sha256sum`, `find`, `sort`, `head`).

No new environment variables: the specs reuse existing suite knobs
(`E2E_PVC_SIZE`, `E2E_PROBE_IMAGE`, namespace, ESC names); Block PVCs use a
fixed 256Mi size.
