### PR TITLE
Sync base-images v1.3.5, Go 1.26.5, lib-helm 1.72.9

### DIFF
--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -10,7 +10,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v0.5.79"
+  BASE_IMAGES_VERSION: "v1.3.5"
 on:
   #pull_request:
   # call from trivy_image_check.yaml, which in turn call from pull_request

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -11,7 +11,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v0.5.79"
+  BASE_IMAGES_VERSION: "v1.3.5"
 on:
   push:
     tags:

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/deckhouse/sds-elastic/api
 
-go 1.25.10
+go 1.26.5
 require (
 	k8s.io/api v0.34.1
 	k8s.io/apimachinery v0.34.1

--- a/hooks/go/go.mod
+++ b/hooks/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/deckhouse/sds-elastic/hooks/go
 
-go 1.25.10
+go 1.26.5
 require (
 	github.com/deckhouse/module-sdk v0.7.0
 	github.com/deckhouse/sds-common-lib v0.6.3

--- a/images/controller/go.mod
+++ b/images/controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/deckhouse/sds-elastic/images/controller
 
-go 1.25.10
+go 1.26.5
 require (
 	github.com/deckhouse/sds-elastic/api v0.0.0
 	github.com/go-logr/logr v1.4.2

--- a/images/webhooks/go.mod
+++ b/images/webhooks/go.mod
@@ -1,6 +1,6 @@
 module github.com/deckhouse/sds-elastic/images/webhooks
 
-go 1.25.10
+go 1.26.5
 require (
 	github.com/onsi/ginkgo/v2 v2.23.1
 	github.com/onsi/gomega v1.36.2


### PR DESCRIPTION
## Description
Automated tooling sync for **sds-elastic** (scheduled `sync_storage_modules_tooling.py`).

- **BASE_IMAGES_VERSION**: `v0.5.79` → `v1.3.5` in `.github/workflows/*.yml`.
- **Go**: set `go 1.26.5` in **4** `go.mod` file(s) under `api/`, `images/` and `hooks/` (aligned with default `golang` image from `base_images.yml`).
- **lib-helm**: already **1.72.9**; chart bundle in `charts/` unchanged.

## Why do we need it, and what problem does it solve?
Keeps the module aligned with the latest **deckhouse/container-base/base-images** release and **deckhouse/lib-helm**
so CI and image builds use current base image digests, Go toolchain version, and Helm library charts.

## What is the expected result?
- Pipelines resolve `BASE_IMAGES_VERSION` to the new (or current) tag and download matching `base_images.yml`.
- Go code under `api/`, `images/` and `hooks/` declares the same Go version as the default `golang` toolchain in `base_images.yml`.
- `charts/` contains the current `deckhouse_lib_helm-*.tgz` when an update was required.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
