### PR TITLE
ci(gitleaks): move the scan action to modules-actions@v16

### DIFF
--- a/.github/workflows/gitleaks-scan-on-pr.yml
+++ b/.github/workflows/gitleaks-scan-on-pr.yml
@@ -30,6 +30,6 @@ jobs:
       pull-requests: read
     steps:
       - name: Run Gitleaks diff scan
-        uses: deckhouse/modules-actions/gitleaks@v6
+        uses: deckhouse/modules-actions/gitleaks@v16
         with:
           scan_mode: "diff"

--- a/.github/workflows/gitleaks-scan-on-schedule.yml
+++ b/.github/workflows/gitleaks-scan-on-schedule.yml
@@ -32,6 +32,6 @@ jobs:
       pull-requests: read
     steps:
       - name: Run Gitleaks diff scan
-        uses: deckhouse/modules-actions/gitleaks@v6
+        uses: deckhouse/modules-actions/gitleaks@v16
         with:
           scan_mode: "full"


### PR DESCRIPTION
Moves the gitleaks scan action from `deckhouse/modules-actions/gitleaks@v6` to `@v16`.

## Why

`v6` predates the centralized gitleaks config entirely — it has no `gitleaks/config/` directory, and its config step greps for an undotted `gitleaks.toml`. This module ships no `.gitleaks.toml` at all, so the scan has been running with bare gitleaks defaults.

`v16` passes the centralized `gitleaks.base.toml`, which adds the three rules that exist in no default ruleset — `werf-secret-key`, `hashicorp-vault-token`, `openbao-token` — plus the shared allowlists (`go.mod`, `go.sum`, `h1:` checksums). Measured on a scratch repo with a live-format Vault token and a 32-hex `.werf_secret_key`: the base config reports both, bare defaults report neither.

No module config is needed here. Because there is no `.gitleaks.toml`, `v16` passes the base config directly and nothing has to be declared on this side.

## Verification

Reproduced the v16 layout locally and scanned at full history scope across all live refs:

```
$ gitleaks detect --no-banner -c gitleaks.base.toml --source . --log-opts "--remotes=origin --tags"
INF no leaks found
```

Same result for all 17 storage modules, so re-enabling the centralized rules turns nobody red.

Only the `gitleaks` action is repinned — `build`, `cve_scan`, `go_*` and `deploy` keep their own refs. No change is needed in `modules-actions` itself.
