### PR TITLE
fix(crds): declare status.conditions as a keyed list

### DIFF
--- a/crds/elasticcluster.yaml
+++ b/crds/elasticcluster.yaml
@@ -502,6 +502,9 @@ spec:
                         cluster first leaves the standard profile.
                 conditions:
                   type: array
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - type
                   description: |
                     Per-component conditions: `StorageReady`, `CephClusterReady`,
                     `CredentialsReady`, `CsiCephReady`, `UpgradeReady`,

--- a/crds/elasticstorageclass.yaml
+++ b/crds/elasticstorageclass.yaml
@@ -119,6 +119,9 @@ spec:
                     - Error
                 conditions:
                   type: array
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - type
                   description: |
                     Per-component conditions: `PoolReady`, `CsiStorageClassReady`,
                     and the aggregate `Ready`.


### PR DESCRIPTION
## Description

Adds `x-kubernetes-list-type: map` and `x-kubernetes-list-map-keys: [type]` to `status.conditions` in the ElasticCluster and ElasticStorageClass CRDs.

No controller code changes. No effect on any component outside this module's own CRDs.

## Why do we need it, and what problem does it solve?

The Go types already carry the correct `+listType=map` / `+listMapKey=type` markers, but the markers never reach the cluster: `hack/generate_code.sh` runs `controller-gen` only for deepcopy, so the CRD schemas are hand-maintained and have drifted from the API types.

With the array left untyped, the API server treats `status.conditions` as atomic:

- it enforces no uniqueness on the condition type, so nothing at the schema level prevents two entries with `type: Ready`;
- server-side apply replaces the entire list rather than merging per type, so two field managers writing different conditions overwrite each other.

Both kinds publish per-stage conditions alongside an aggregate `Ready`, so per-type merge semantics are what the controller already assumes.

This came out of a review of `status.conditions` across the storage modules. The same gap exists in sds-object, csi-scsi-generic and sds-node-configurator, each fixed in its own PR.

## What is the expected result?

After applying, the CRD schema for both kinds carries the list-type markers:

```
kubectl get crd elasticclusters.storage.deckhouse.io -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.status.properties.conditions.x-kubernetes-list-type}'
# map
```

Existing objects and their conditions are unaffected — this only constrains how the API server merges and validates future writes. Duplicate condition types, if any exist on live objects, will be rejected on the next write to that object and have to be cleaned up; the controller writes conditions through `apimeta.SetStatusCondition`, which never creates duplicates, so this is not expected in practice.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

Schema-only change with no Go code, so there is nothing to unit test. Not yet verified on a live cluster — worth a look at whether any existing ElasticCluster carries duplicate condition types before this is rolled out.
