### PR TITLE
fix(ceph): install requests so the telemetry mgr module can load

### DIFF
--- a/images/ceph/werf.inc.yaml
+++ b/images/ceph/werf.inc.yaml
@@ -95,9 +95,23 @@ shell:
     - |
       ln -sf /usr/lib/udev/udevadm /usr/sbin/udevadm
       command -v udevadm
-    # ceph-volume (python3.12) runtime deps, shipped as wheels by python-wheel and
-    # resolved from the /wheels find-links dir (--no-index, offline).
+    # python3.12 runtime deps, shipped as wheels by python-wheel and resolved
+    # from the /wheels find-links dir (--no-index, offline).
     # PyYAML + packaging: imported directly by ceph_volume.
+    # requests: imported at module scope by the always-on `telemetry` mgr module
+    # (and by `feedback`). Without it ceph-mgr cannot import telemetry at all, so
+    # the cluster sits in HEALTH_WARN with MGR_MODULE_DEPENDENCY — and the reason
+    # telemetry reports renders empty ("Module 'telemetry' has failed dependency:
+    # "), which reads like a can_run() rejection rather than the missing import it
+    # actually is. Its transitive deps (urllib3, certifi, idna,
+    # charset_normalizer) come from the same /wheels dir; urllib3 is additionally
+    # imported directly by the `k8sevents` and `rook` mgr modules, which otherwise
+    # record a crash on every ceph-mgr start and raise RECENT_MGR_MODULE_CRASH.
+    # Not fixed here and deliberately left out: `diskprediction_local` needs scipy
+    # (no wheel in the catalog at all), and `restful`/`dashboard`/`cephadm` import
+    # cryptography, a PyO3 extension that refuses to load in the subinterpreter
+    # ceph-mgr runs each module in — every cryptography wheel the catalog ships is
+    # the Rust build, so no wheel choice fixes those.
     # setuptools is deliberately NOT installed. ceph_volume/main.py is the only
     # thing in the image that ever mentions pkg_resources, and it does so purely
     # as a fallback for pythons without importlib.metadata:
@@ -118,7 +132,9 @@ shell:
     - |
       python3.12 -m pip install --no-cache-dir --no-index -f file:///wheels \
         PyYAML \
-        packaging
+        packaging \
+        requests
+      python3.12 -c 'import requests, urllib3; print("requests", requests.__version__, "urllib3", urllib3.__version__)'
     # container-base python3.12 is built WITHOUT the stdlib _sqlite3 C extension
     # (its Modules/Setup omits _sqlite3), but ceph-mgr's mgr_module.py does
     # `import sqlite3` at load time, so every python mgr module fails its


### PR DESCRIPTION
## Description

Adds `requests` to the offline wheel install in `images/ceph/werf.inc.yaml`, plus a build-time import assertion. `urllib3`, `certifi`, `idna` and `charset_normalizer` come along as transitive deps.

No new build input: every one of those wheels is already shipped by the `python-wheel` catalog package that the image installs, so the `--no-index -f file:///wheels` install resolves them offline exactly as `PyYAML`/`packaging` do today.

## Why do we need it, and what problem does it solve?

Found while switching a live cluster from `v0.0.1` to `main`. The container-base/pm ceph image ships no `requests`, and the always-on `telemetry` mgr module imports it at module scope, so ceph-mgr cannot import the module at all:

```
[WRN] MGR_MODULE_DEPENDENCY: 2 mgr modules have failed dependencies
    Module 'telemetry' has failed dependency:
```

The reason renders empty, which makes it look like a `can_run()` rejection — `telemetry.can_run()` in fact returns `True, ''`. The actual cause is visible only in the crash record:

```
File "/usr/share/ceph/mgr/telemetry/module.py", line 14, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```

`urllib3` is separately imported by the `k8sevents` and `rook` mgr modules, and `requests` by `feedback`. All three record a crash on every ceph-mgr start, which is what raises `RECENT_MGR_MODULE_CRASH` (13 records across 2 mgr daemons on a 4-node cluster).

## What is the expected result?

`MGR_MODULE_DEPENDENCY` no longer lists `telemetry`, and `k8sevents` / `rook` / `feedback` stop recording crashes on mgr start.

Two known findings are deliberately **not** addressed here, because neither is fixable by a wheel choice:

- `restful`, `dashboard` and `cephadm` import `cryptography`, a PyO3 extension that refuses to initialise in the CPython subinterpreter ceph-mgr runs each module in (`ImportError: PyO3 modules do not yet support subinterpreters`). Every `cryptography` wheel in the catalog (41.0.5 … 44.0.1) is the Rust build. `restful` is the only one of the three that is enabled, and it is enabled by Ceph's own default `mgr_initial_modules`, not by this module.
- `diskprediction_local` needs `scipy`, for which the catalog ships no wheel at all.

Also unrelated to this PR and tracked separately: all 4 OSDs report `unable to load:snappy` (`BLUESTORE_NO_COMPRESSION`) because the catalog's `libsnappy.so.1` is built with `-fno-rtti` and therefore exports no typeinfo for `snappy::Source`. Fixed in container-base MR [!254](https://fox.flant.com/deckhouse/container-base/base-images/-/merge_requests/254).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
