### PR TITLE
fix(controller): disable the restful mgr module

### DIFF
--- a/images/controller/internal/builder/builders_test.go
+++ b/images/controller/internal/builder/builders_test.go
@@ -188,6 +188,23 @@ var _ = Describe("builders", func() {
 	})
 
 	Describe("ECCephCluster", func() {
+		It("enables pg_autoscaler and disables restful in spec.mgr.modules", func() {
+			cc := ECCephCluster(ec, "d8-sds-elastic", "img", int32(3), resource.MustParse("50Gi"), nil, 3, 2)
+
+			mods, found, err := unstructuredNestedSlice(cc, "spec", "mgr", "modules")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+
+			got := map[string]bool{}
+			for _, m := range mods {
+				entry := m.(map[string]interface{})
+				got[entry["name"].(string)] = entry["enabled"].(bool)
+			}
+			Expect(got).To(HaveKeyWithValue("pg_autoscaler", true))
+			Expect(got).To(HaveKeyWithValue("restful", false),
+				"restful imports cryptography (PyO3), which cannot load in a ceph-mgr subinterpreter; leaving it on parks the cluster in HEALTH_WARN with MGR_MODULE_DEPENDENCY")
+		})
+
 		It("threads pvcStorageRequest into volumeClaimTemplates[0].spec.resources.requests.storage", func() {
 			pvcReq := resource.MustParse("50Gi")
 			cc := ECCephCluster(ec, "d8-sds-elastic", "registry.example.com/ceph:v19", int32(3), pvcReq, nil, 3, 2)

--- a/images/controller/internal/builder/ec_rook.go
+++ b/images/controller/internal/builder/ec_rook.go
@@ -54,7 +54,7 @@ func ECCephClusterDataDirHostPath(ec *v1alpha1.ElasticCluster) string {
 //     daemons run with allowMultiplePerNode=false and no
 //     volumeClaimTemplate (mon data sits on the host path; survival
 //     across namespace deletion is achieved by ElasticClusterCredential).
-//   - mgr modules: pg_autoscaler enabled.
+//   - mgr modules: pg_autoscaler enabled, restful disabled.
 //   - network.provider=host. addressRanges populated only when
 //     ec.Spec.Network is set; otherwise Rook listens on every host IP.
 //   - network.connections.{encryption,compression}=false, requireMsgr2=false.
@@ -91,6 +91,18 @@ func ECCephCluster(
 		"allowMultiplePerNode": false,
 		"modules": []interface{}{
 			map[string]interface{}{"name": "pg_autoscaler", "enabled": true},
+			// Ceph's own mgr_initial_modules default turns `restful` on at cluster
+			// bootstrap. It imports pyOpenSSL -> cryptography, a PyO3 extension that
+			// refuses to initialise in the CPython subinterpreter ceph-mgr runs each
+			// module in ("PyO3 modules do not yet support subinterpreters"), so the
+			// module can never load and the cluster sits in HEALTH_WARN with
+			// MGR_MODULE_DEPENDENCY. No wheel choice fixes it: every cryptography
+			// release the container-base catalog ships is the Rust build. Nothing in
+			// Rook, csi-ceph or Deckhouse talks to restful — it is deprecated
+			// upstream in favour of the dashboard REST API — so turn it off. Rook
+			// translates enabled=false into `ceph mgr module disable restful`, which
+			// also cleans up clusters bootstrapped before this change.
+			map[string]interface{}{"name": "restful", "enabled": false},
 		},
 	}
 


### PR DESCRIPTION
## Description

Adds `{"name": "restful", "enabled": false}` to `spec.mgr.modules` in the `CephCluster` the controller builds, plus a unit test asserting the module set.

## Why do we need it, and what problem does it solve?

Found while switching a live cluster from `v0.0.1` to `main`. Ceph's own `mgr_initial_modules` default enables `restful` at cluster bootstrap — this module does not enable it, `spec.mgr.modules` only listed `pg_autoscaler`. `restful` imports `pyOpenSSL` → `cryptography`, which is a PyO3 extension, and ceph-mgr runs every python module in its own CPython subinterpreter:

```
[WRN] MGR_MODULE_DEPENDENCY: 2 mgr modules have failed dependencies
    Module 'restful' has failed dependency: PyO3 modules do not yet support
    subinterpreters, see https://github.com/PyO3/pyo3/issues/576
```

So the module can never load, and the cluster is parked in `HEALTH_WARN` permanently. That is not only cosmetic here: the status propagates into `ElasticCluster.status.health`, so the CR keeps reporting a degraded cluster while storage is fully healthy, and anything alerting on either signal fires forever.

No wheel choice fixes this — every `cryptography` release the container-base catalog ships (41.0.5 … 44.0.1) is the Rust build; the last cffi-only release is 3.4.8 from 2021. Nothing in Rook, csi-ceph or Deckhouse talks to `restful`, and it is deprecated upstream in favour of the dashboard REST API.

## What is the expected result?

`MGR_MODULE_DEPENDENCY` no longer lists `restful`. Rook translates `enabled: false` into `ceph mgr module disable restful`, so this also cleans up clusters bootstrapped before the change, not just new ones.

Together with #72 (which adds `requests` for the always-on `telemetry` module), `MGR_MODULE_DEPENDENCY` should clear entirely.

Deliberately **not** addressed here: `dashboard` and `cephadm` hit the same PyO3 wall, and `diskprediction_local` needs `scipy` which the catalog has no wheel for. All three are already disabled, but ceph-mgr imports every directory under `/usr/share/ceph/mgr` at startup to enumerate modules, so they still record a crash on each mgr start and raise `RECENT_MGR_MODULE_CRASH`. Removing them from the image is the only way to stop that, which is a separate decision — this PR is the low-risk half.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
