### PR TITLE
fix(conditions): a stage with no verdict makes the phase Pending, not Ready

### DIFF
--- a/images/controller/internal/controller/elastic_cluster_controller.go
+++ b/images/controller/internal/controller/elastic_cluster_controller.go
@@ -536,10 +536,10 @@ func (r *ElasticClusterReconciler) updateECStatus(ctx context.Context, ec *v1alp
 // False with an Error reason directly. Aggregate Ready and the
 // UpgradeInProgress signal are intentionally excluded.
 //
-//   - empty conditions slice                          → Pending
-//   - any stage False with Reason=="Error"            → Error
+//   - any stage without a condition, or Unknown        → Pending
+//   - any stage False with Reason=="Error"             → Error
 //   - any stage False (other reasons, e.g. InProgress) → InProgress
-//   - all stages True (or absent)                     → Ready
+//   - all stages True                                  → Ready
 func deriveECPhase(conditions []metav1.Condition) string {
 	return ecStages().Phase(conditions)
 }

--- a/images/controller/internal/controller/elastic_cluster_helpers_test.go
+++ b/images/controller/internal/controller/elastic_cluster_helpers_test.go
@@ -24,6 +24,25 @@ import (
 	v1alpha1 "github.com/deckhouse/sds-elastic/api/v1alpha1"
 )
 
+// stageConditions builds a full set of EC stage conditions, which is what the
+// FSM always writes, so a fixture only has to state what it is about.
+func stageConditions(status metav1.ConditionStatus, reason string) []metav1.Condition {
+	conds := make([]metav1.Condition, 0, len(stageOrder))
+	for _, t := range stageOrder {
+		conds = append(conds, metav1.Condition{Type: t, Status: status, Reason: reason})
+	}
+	return conds
+}
+
+func setStageCondition(conds []metav1.Condition, condType string, status metav1.ConditionStatus, reason string) {
+	for i := range conds {
+		if conds[i].Type == condType {
+			conds[i].Status, conds[i].Reason = status, reason
+			return
+		}
+	}
+}
+
 var _ = Describe("ElasticCluster pure helpers", func() {
 	DescribeTable("versionMatches",
 		func(running, desired string, want bool) {
@@ -51,20 +70,29 @@ var _ = Describe("ElasticCluster pure helpers", func() {
 			Expect(deriveECPhase(nil)).To(Equal(v1alpha1.PhasePending))
 		})
 
+		// The fixtures carry every stage, because that is what the FSM leaves
+		// behind: advance gates the remaining stages whenever one does not pass,
+		// so a half-reported set never reaches the API server. A phase derived
+		// from an incomplete set is Pending, which is asserted separately.
 		It("returns Error when any stage has Error reason", func() {
-			conds := []metav1.Condition{
-				{Type: v1alpha1.ECConditionStorageReady, Status: metav1.ConditionFalse, Reason: "Error"},
-				{Type: v1alpha1.ECConditionCephClusterReady, Status: metav1.ConditionFalse, Reason: "InProgress"},
-			}
+			conds := stageConditions(metav1.ConditionTrue, "Ready")
+			setStageCondition(conds, v1alpha1.ECConditionStorageReady, metav1.ConditionFalse, "Error")
+			setStageCondition(conds, v1alpha1.ECConditionCephClusterReady, metav1.ConditionFalse, "InProgress")
+
 			Expect(deriveECPhase(conds)).To(Equal(v1alpha1.PhaseError))
 		})
 
 		It("returns InProgress when a stage is False but not Error", func() {
-			conds := []metav1.Condition{
-				{Type: v1alpha1.ECConditionStorageReady, Status: metav1.ConditionTrue},
-				{Type: v1alpha1.ECConditionCephClusterReady, Status: metav1.ConditionFalse, Reason: "InProgress"},
-			}
+			conds := stageConditions(metav1.ConditionTrue, "Ready")
+			setStageCondition(conds, v1alpha1.ECConditionCephClusterReady, metav1.ConditionFalse, "InProgress")
+
 			Expect(deriveECPhase(conds)).To(Equal(v1alpha1.PhaseInProgress))
+		})
+
+		It("is Pending while any stage has no verdict", func() {
+			conds := stageConditions(metav1.ConditionTrue, "Ready")[1:]
+
+			Expect(deriveECPhase(conds)).To(Equal(v1alpha1.PhasePending))
 		})
 
 		It("returns Ready when all stage conditions are True", func() {

--- a/images/controller/internal/controller/elastic_storage_class_controller_test.go
+++ b/images/controller/internal/controller/elastic_storage_class_controller_test.go
@@ -40,11 +40,22 @@ var _ = Describe("ElasticStorageClass FSM and Reconcile", func() {
 			Expect(deriveESCPhase(nil)).To(Equal(v1alpha1.PhasePending))
 		})
 
+		// Both stages are present: advance gates the remaining ones whenever a
+		// stage does not pass, so a half-reported set never reaches the API
+		// server, and a phase derived from one is Pending.
 		It("returns Error when a stage has Error reason", func() {
 			conds := []metav1.Condition{
 				{Type: v1alpha1.ESCConditionPoolReady, Status: metav1.ConditionFalse, Reason: "Error"},
+				{Type: v1alpha1.ESCConditionCsiStorageClassReady, Status: metav1.ConditionFalse, Reason: "WaitingForPrev"},
 			}
 			Expect(deriveESCPhase(conds)).To(Equal(v1alpha1.PhaseError))
+		})
+
+		It("is Pending while a stage has no verdict", func() {
+			conds := []metav1.Condition{
+				{Type: v1alpha1.ESCConditionPoolReady, Status: metav1.ConditionTrue},
+			}
+			Expect(deriveESCPhase(conds)).To(Equal(v1alpha1.PhasePending))
 		})
 
 		It("returns Ready when all stages are True", func() {

--- a/images/controller/internal/controller/stages.go
+++ b/images/controller/internal/controller/stages.go
@@ -33,16 +33,23 @@ const (
 
 // stageVocabulary is what both reconcilers report their stages with.
 //
-// SkipMissing keeps the reading these reconcilers have always had: a stage with
-// no condition is not evidence of a problem. The library defaults the other way,
-// on the grounds that a stage never evaluated is not evidence of health either;
-// moving to that changes what users see and belongs in a commit of its own.
+// SkipMissing is deliberately left off, so a stage carrying no condition
+// aggregates to Unknown and the phase reads Pending. A stage that has never been
+// evaluated is not evidence that the resource is healthy, and answering Ready on
+// a set of verdicts that is not complete is how a resource gets called usable on
+// nobody's word.
+//
+// It costs nothing today: every path that flushes the status has written the
+// whole stage set, because advance gates the remaining stages whenever one does
+// not pass. The reading only differs after a stage is added to stageOrder — the
+// resources already in the cluster then report Pending until the controller has
+// reconciled them once, which is the honest answer while the new stage has no
+// verdict.
 var stageVocabulary = conditions.Stages{
-	Passed:      reasonReady,
-	Failed:      reasonError,
-	InProgress:  reasonInProgress,
-	Blocked:     reasonWaitingForPrev,
-	SkipMissing: true,
+	Passed:     reasonReady,
+	Failed:     reasonError,
+	InProgress: reasonInProgress,
+	Blocked:    reasonWaitingForPrev,
 }
 
 // ecStages and escStages pair that vocabulary with each reconciler's stage


### PR DESCRIPTION
## Description

The move onto `conditions.Stages` kept `SkipMissing` so that nothing users see would change in that commit. This is the change it was deferring.

A stage carrying no condition now aggregates to `Unknown`, so the phase reads `Pending` instead of being derived from whichever stages happen to be present.

## Why do we need it, and what problem does it solve?

A stage that has never been evaluated is not evidence that the resource is healthy. Under the old reading an `ElasticCluster` whose `StorageReady` was `True` and whose other four stages had never been written reported `Ready` — usable, on the strength of one verdict out of five.

## What is the expected result?

**Nothing changes today.** Every path that flushes the status has already written the whole stage set: `advance` gates the remaining stages whenever one does not pass, and this module has no direct stage writes at all — every stage goes through `advance` / `advanceESC`.

The reading only differs **after a stage is added to `stageOrder`**. Resources already in the cluster then report `Pending` until the controller has reconciled them once, instead of continuing to claim `Ready` while the new stage has no verdict. That window is short — the controller reconciles everything on startup — and `Pending` is the honest answer during it.

Three unit fixtures relied on the old reading: they built two of the five EC stages, or one of the two ESC stages, and expected a phase derived from them. What they were actually asserting is reason precedence — `Error` outranks `InProgress` — and the incompleteness was incidental. They now carry the full stage set and assert the same property. Two cases were added to pin the new answer directly.

The teardown assertions in the e2e suite are unaffected: `patchECDeleteCondition` and `patchESCDeleteCondition` write the aggregate themselves rather than deriving it from stages.

Checked: `go build`, `go vet`, `go test` clean for `api` and `images/controller`; all specs pass; imports verified against this repo's `gci` sections directly, since the v1-format `.golangci.yaml` here cannot be loaded by a v2 binary.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
