### PR TITLE
refactor(conditions): report stages with the shared reason vocabulary

### DIFF
--- a/images/controller/internal/controller/conditions_contract_test.go
+++ b/images/controller/internal/controller/conditions_contract_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/deckhouse/sds-common-lib/conditions"
 	"github.com/deckhouse/sds-elastic/api/v1alpha1"
 )
 
@@ -69,7 +70,7 @@ var _ = Describe("ElasticCluster condition contract", func() {
 				"a stage that succeeded must let the FSM proceed")
 		}
 		setUpgradeInProgress(status, false, "no upgrade in progress")
-		status.setCondition(v1alpha1.ECConditionReady, metav1.ConditionTrue, "Ready", "all stages reconciled")
+		status.setCondition(v1alpha1.ECConditionReady, metav1.ConditionTrue, conditions.ReasonReconciled, "all stages reconciled")
 
 		Expect(conditionTypesOf(status.conditions)).To(ConsistOf(v1alpha1.ECConditionTypes))
 	})
@@ -123,7 +124,7 @@ var _ = Describe("ElasticStorageClass condition contract", func() {
 		for _, stage := range escStageOrder {
 			Expect(r.advanceESC(status, stage, true, "done", nil)).To(BeTrue())
 		}
-		status.setCondition(v1alpha1.ESCConditionReady, metav1.ConditionTrue, "Ready", "all stages reconciled")
+		status.setCondition(v1alpha1.ESCConditionReady, metav1.ConditionTrue, conditions.ReasonReconciled, "all stages reconciled")
 
 		Expect(conditionTypesOf(status.conditions)).To(ConsistOf(v1alpha1.ESCConditionTypes))
 	})

--- a/images/controller/internal/controller/elastic_cluster_controller.go
+++ b/images/controller/internal/controller/elastic_cluster_controller.go
@@ -53,11 +53,11 @@ import (
 // (done, message, error). The reconciler funnels every stage outcome
 // through advance(), which:
 //
-//   - on err  → condition False/Error  + gates downstream + aggregate Ready=False/WaitingForPrev
-//   - on !done → condition False/InProgress + gates downstream + aggregate Ready=False/WaitingForPrev
-//   - on done  → condition True/Ready  and the FSM is allowed to progress
+//   - on err   → False/ReconcileFailed + gates downstream + aggregate Ready=False/WaitingForDependency
+//   - on !done → False/Pending         + gates downstream + aggregate Ready=False/WaitingForDependency
+//   - on done  → True/Reconciled       and the FSM is allowed to progress
 //
-// Both Error and InProgress paths share the same gating so the published
+// Both the failed and the pending paths share the same gating so the published
 // status never carries a stale "Ready=True" on a downstream stage when an
 // upstream stage is unhealthy. The aggregate Ready=True is set only after
 // every stage passes.
@@ -281,7 +281,7 @@ func (r *ElasticClusterReconciler) reconcileNormal(ctx context.Context, ec *v1al
 	// (CephCluster.status.phase=Progressing for the entire mon → mgr →
 	// osd → mds rollout window), so r.advance(...) below would otherwise
 	// trip gateAfter and the UpgradeInProgress condition would flap to
-	// False/WaitingForPrev exactly while the rollout is happening. Doing
+	// False/WaitingForDependency exactly while the rollout is happening. Doing
 	// the publish here keeps the signal True for the duration of the
 	// rollout, regardless of the FSM gate.
 	if upgradeProbe != nil {
@@ -312,20 +312,21 @@ func (r *ElasticClusterReconciler) reconcileNormal(ctx context.Context, ec *v1al
 	}
 	setUpgradeInProgress(status, inProgress, msg)
 
-	status.setCondition(v1alpha1.ECConditionReady, metav1.ConditionTrue, "Ready", "All stages reconciled")
+	status.setCondition(v1alpha1.ECConditionReady, metav1.ConditionTrue, conditions.ReasonReconciled,
+		"All stages reconciled")
 	return r.finishReconcile(ctx, ec, status, nil)
 }
 
 // advance records the outcome of a stage on the status builder and returns
 // whether the FSM is allowed to progress to the next stage.
 //
-//   - err != nil  → condition False/Error, downstream gated, return false.
-//   - !done       → condition False/<reason or InProgress>, downstream gated,
+//   - err != nil  → condition False/ReconcileFailed, downstream gated, return false.
+//   - !done       → condition False/<reason or Pending>, downstream gated,
 //     return false. `reason` lets a stage publish a richer machine-readable
 //     cause (e.g. "WaitingForLVG", "WaitingForLLV") so a UI can dispatch on
 //     reason without parsing the human-readable message. Empty `reason`
-//     falls back to the generic "InProgress".
-//   - done        → condition True/Ready, return true.
+//     falls back to the generic Pending.
+//   - done        → condition True/Reconciled, return true.
 //
 // The aggregate Ready condition is also pushed to False on every non-pass
 // outcome so the printer column never lies about cluster readiness while
@@ -335,8 +336,8 @@ func (r *ElasticClusterReconciler) advance(status *ecStatusBuilder, condType str
 }
 
 // gateAfter marks every stage condition strictly downstream of `gateAfter`
-// as False/WaitingForPrev, plus the aggregate Ready. Idempotent; safe to
-// call from both the Error and InProgress paths.
+// as False/WaitingForDependency, plus the aggregate Ready. Idempotent; safe to
+// call from both the failed and the pending paths.
 //
 // UpgradeInProgress is intentionally NOT touched here. It is a signal,
 // not a stage, and is published by two authoritative sites:
@@ -349,9 +350,9 @@ func (r *ElasticClusterReconciler) advance(status *ecStatusBuilder, condType str
 //   - ensureUpgrade — runs at the UpgradeReady stage and gates that
 //     condition; reuses the same probe.
 //
-// Forcing WaitingForPrev here used to clobber the True signal exactly
-// while a rolling upgrade was rolling, surfacing as `UPGRADING=False
-// REASON=WaitingForPrev` immediately after the upgrade started. Letting
+// Forcing the gate's blocked reason here used to clobber the True signal
+// exactly while a rolling upgrade was rolling, surfacing as
+// `UPGRADING=False` immediately after the upgrade started. Letting
 // the explicit publishers own the condition keeps the signal accurate
 // for the entire rollout. When upstream stages fail before the
 // CephCluster has been fetched (e.g. StorageReady error), the previous
@@ -536,10 +537,10 @@ func (r *ElasticClusterReconciler) updateECStatus(ctx context.Context, ec *v1alp
 // False with an Error reason directly. Aggregate Ready and the
 // UpgradeInProgress signal are intentionally excluded.
 //
-//   - any stage without a condition, or Unknown        → Pending
-//   - any stage False with Reason=="Error"             → Error
-//   - any stage False (other reasons, e.g. InProgress) → InProgress
-//   - all stages True                                  → Ready
+//   - any stage without a condition, or Unknown           → Pending
+//   - any stage False with Reason=="ReconcileFailed"      → Error
+//   - any stage False (other reasons, e.g. Pending)       → InProgress
+//   - all stages True                                     → Ready
 func deriveECPhase(conditions []metav1.Condition) string {
 	return ecStages().Phase(conditions)
 }

--- a/images/controller/internal/controller/elastic_cluster_controller_test.go
+++ b/images/controller/internal/controller/elastic_cluster_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/deckhouse/sds-common-lib/conditions"
 	v1alpha1 "github.com/deckhouse/sds-elastic/api/v1alpha1"
 	"github.com/deckhouse/sds-elastic/images/controller/internal/external"
 )
@@ -49,7 +50,7 @@ var _ = Describe("ElasticClusterReconciler.Reconcile", func() {
 			Expect(findCondition(latest.Status.Conditions, v1alpha1.ECConditionStorageReady).Status).
 				To(Equal(metav1.ConditionFalse))
 			Expect(findCondition(latest.Status.Conditions, v1alpha1.ECConditionCephClusterReady).Reason).
-				To(Equal("WaitingForPrev"))
+				To(Equal(conditions.ReasonWaitingForDependency))
 			Expect(findCondition(latest.Status.Conditions, v1alpha1.ECConditionReady).Status).
 				To(Equal(metav1.ConditionFalse))
 		})

--- a/images/controller/internal/controller/elastic_cluster_fsm_test.go
+++ b/images/controller/internal/controller/elastic_cluster_fsm_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/deckhouse/sds-common-lib/conditions"
 	v1alpha1 "github.com/deckhouse/sds-elastic/api/v1alpha1"
 )
 
@@ -44,20 +45,20 @@ var _ = Describe("ElasticCluster FSM scaffolding", func() {
 			c := findCondition(status.conditions, v1alpha1.ECConditionStorageReady)
 			Expect(c).NotTo(BeNil())
 			Expect(c.Status).To(Equal(metav1.ConditionTrue))
-			Expect(c.Reason).To(Equal("Ready"))
+			Expect(c.Reason).To(Equal(conditions.ReasonReconciled))
 		})
 
 		It("gates downstream on error", func() {
 			Expect(r.advance(status, v1alpha1.ECConditionStorageReady, false, "", "", errors.New("boom"))).To(BeFalse())
-			Expect(findCondition(status.conditions, v1alpha1.ECConditionStorageReady).Reason).To(Equal("Error"))
-			Expect(findCondition(status.conditions, v1alpha1.ECConditionCephClusterReady).Reason).To(Equal("WaitingForPrev"))
+			Expect(findCondition(status.conditions, v1alpha1.ECConditionStorageReady).Reason).To(Equal(conditions.ReasonReconcileFailed))
+			Expect(findCondition(status.conditions, v1alpha1.ECConditionCephClusterReady).Reason).To(Equal(conditions.ReasonWaitingForDependency))
 			Expect(findCondition(status.conditions, v1alpha1.ECConditionReady).Status).To(Equal(metav1.ConditionFalse))
 		})
 
 		It("gates downstream on in-progress with default reason", func() {
 			Expect(r.advance(status, v1alpha1.ECConditionCephClusterReady, false, "", "waiting", nil)).To(BeFalse())
-			Expect(findCondition(status.conditions, v1alpha1.ECConditionCephClusterReady).Reason).To(Equal("InProgress"))
-			Expect(findCondition(status.conditions, v1alpha1.ECConditionCredentialsReady).Reason).To(Equal("WaitingForPrev"))
+			Expect(findCondition(status.conditions, v1alpha1.ECConditionCephClusterReady).Reason).To(Equal(conditions.ReasonPending))
+			Expect(findCondition(status.conditions, v1alpha1.ECConditionCredentialsReady).Reason).To(Equal(conditions.ReasonWaitingForDependency))
 		})
 
 		It("preserves a caller-supplied reason on in-progress", func() {
@@ -105,8 +106,8 @@ var _ = Describe("ElasticCluster FSM scaffolding", func() {
 
 	Describe("isAggregateReady", func() {
 		It("reads the last Ready condition", func() {
-			status.setCondition(v1alpha1.ECConditionReady, metav1.ConditionFalse, "WaitingForPrev", "")
-			status.setCondition(v1alpha1.ECConditionReady, metav1.ConditionTrue, "Ready", "")
+			status.setCondition(v1alpha1.ECConditionReady, metav1.ConditionFalse, conditions.ReasonWaitingForDependency, "")
+			status.setCondition(v1alpha1.ECConditionReady, metav1.ConditionTrue, conditions.ReasonReconciled, "")
 			Expect(isAggregateReady(status)).To(BeTrue())
 		})
 	})

--- a/images/controller/internal/controller/elastic_cluster_helpers_test.go
+++ b/images/controller/internal/controller/elastic_cluster_helpers_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/deckhouse/sds-common-lib/conditions"
 	v1alpha1 "github.com/deckhouse/sds-elastic/api/v1alpha1"
 )
 
@@ -75,22 +76,22 @@ var _ = Describe("ElasticCluster pure helpers", func() {
 		// so a half-reported set never reaches the API server. A phase derived
 		// from an incomplete set is Pending, which is asserted separately.
 		It("returns Error when any stage has Error reason", func() {
-			conds := stageConditions(metav1.ConditionTrue, "Ready")
-			setStageCondition(conds, v1alpha1.ECConditionStorageReady, metav1.ConditionFalse, "Error")
-			setStageCondition(conds, v1alpha1.ECConditionCephClusterReady, metav1.ConditionFalse, "InProgress")
+			conds := stageConditions(metav1.ConditionTrue, conditions.ReasonReconciled)
+			setStageCondition(conds, v1alpha1.ECConditionStorageReady, metav1.ConditionFalse, conditions.ReasonReconcileFailed)
+			setStageCondition(conds, v1alpha1.ECConditionCephClusterReady, metav1.ConditionFalse, conditions.ReasonPending)
 
 			Expect(deriveECPhase(conds)).To(Equal(v1alpha1.PhaseError))
 		})
 
 		It("returns InProgress when a stage is False but not Error", func() {
-			conds := stageConditions(metav1.ConditionTrue, "Ready")
-			setStageCondition(conds, v1alpha1.ECConditionCephClusterReady, metav1.ConditionFalse, "InProgress")
+			conds := stageConditions(metav1.ConditionTrue, conditions.ReasonReconciled)
+			setStageCondition(conds, v1alpha1.ECConditionCephClusterReady, metav1.ConditionFalse, conditions.ReasonPending)
 
 			Expect(deriveECPhase(conds)).To(Equal(v1alpha1.PhaseInProgress))
 		})
 
 		It("is Pending while any stage has no verdict", func() {
-			conds := stageConditions(metav1.ConditionTrue, "Ready")[1:]
+			conds := stageConditions(metav1.ConditionTrue, conditions.ReasonReconciled)[1:]
 
 			Expect(deriveECPhase(conds)).To(Equal(v1alpha1.PhasePending))
 		})
@@ -113,7 +114,7 @@ var _ = Describe("ElasticCluster pure helpers", func() {
 				conds = append(conds, metav1.Condition{Type: t, Status: metav1.ConditionTrue})
 			}
 			conds = append(conds,
-				metav1.Condition{Type: v1alpha1.ECConditionReady, Status: metav1.ConditionFalse, Reason: "Error"},
+				metav1.Condition{Type: v1alpha1.ECConditionReady, Status: metav1.ConditionFalse, Reason: conditions.ReasonReconcileFailed},
 				metav1.Condition{Type: v1alpha1.ECConditionUpgradeInProgress, Status: metav1.ConditionTrue},
 			)
 			Expect(deriveECPhase(conds)).To(Equal(v1alpha1.PhaseReady))

--- a/images/controller/internal/controller/elastic_storage_class_controller.go
+++ b/images/controller/internal/controller/elastic_storage_class_controller.go
@@ -264,7 +264,8 @@ func (r *ElasticStorageClassReconciler) reconcileNormal(ctx context.Context, esc
 		return r.finishESCReconcile(ctx, esc, status, err)
 	}
 
-	status.setCondition(v1alpha1.ESCConditionReady, metav1.ConditionTrue, "Ready", "All stages reconciled")
+	status.setCondition(v1alpha1.ESCConditionReady, metav1.ConditionTrue, conditions.ReasonReconciled,
+		"All stages reconciled")
 	return r.finishESCReconcile(ctx, esc, status, nil)
 }
 
@@ -276,7 +277,7 @@ func (r *ElasticStorageClassReconciler) advanceESC(status *escStatusBuilder, con
 }
 
 // gateAfterESC marks every stage strictly downstream of `afterStage` and
-// the aggregate Ready as False/WaitingForPrev.
+// the aggregate Ready as False/WaitingForDependency.
 func gateAfterESC(status *escStatusBuilder, afterStage string) {
 	escStages().Gate(&status.conditions, status.source.Generation, afterStage)
 }

--- a/images/controller/internal/controller/elastic_storage_class_controller_test.go
+++ b/images/controller/internal/controller/elastic_storage_class_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/deckhouse/sds-common-lib/conditions"
 	v1alpha1 "github.com/deckhouse/sds-elastic/api/v1alpha1"
 )
 
@@ -45,8 +46,8 @@ var _ = Describe("ElasticStorageClass FSM and Reconcile", func() {
 		// server, and a phase derived from one is Pending.
 		It("returns Error when a stage has Error reason", func() {
 			conds := []metav1.Condition{
-				{Type: v1alpha1.ESCConditionPoolReady, Status: metav1.ConditionFalse, Reason: "Error"},
-				{Type: v1alpha1.ESCConditionCsiStorageClassReady, Status: metav1.ConditionFalse, Reason: "WaitingForPrev"},
+				{Type: v1alpha1.ESCConditionPoolReady, Status: metav1.ConditionFalse, Reason: conditions.ReasonReconcileFailed},
+				{Type: v1alpha1.ESCConditionCsiStorageClassReady, Status: metav1.ConditionFalse, Reason: conditions.ReasonWaitingForDependency},
 			}
 			Expect(deriveESCPhase(conds)).To(Equal(v1alpha1.PhaseError))
 		})
@@ -94,7 +95,7 @@ var _ = Describe("ElasticStorageClass FSM and Reconcile", func() {
 		It("gates CsiStorageClassReady on pool error", func() {
 			Expect(r.advanceESC(status, v1alpha1.ESCConditionPoolReady, false, "", errors.New("fail"))).To(BeFalse())
 			Expect(findCondition(status.conditions, v1alpha1.ESCConditionCsiStorageClassReady).Reason).
-				To(Equal("WaitingForPrev"))
+				To(Equal(conditions.ReasonWaitingForDependency))
 		})
 	})
 
@@ -111,9 +112,9 @@ var _ = Describe("ElasticStorageClass FSM and Reconcile", func() {
 			latest := &v1alpha1.ElasticStorageClass{}
 			Expect(cl.Get(ctx, types.NamespacedName{Name: escName}, latest)).To(Succeed())
 			Expect(findCondition(latest.Status.Conditions, v1alpha1.ESCConditionPoolReady).Reason).
-				To(Equal("InProgress"))
+				To(Equal(conditions.ReasonPending))
 			Expect(findCondition(latest.Status.Conditions, v1alpha1.ESCConditionCsiStorageClassReady).Reason).
-				To(Equal("WaitingForPrev"))
+				To(Equal(conditions.ReasonWaitingForDependency))
 		})
 
 		It("reaches Ready when pool and csi-ceph SC are Created", func() {

--- a/images/controller/internal/controller/stages.go
+++ b/images/controller/internal/controller/stages.go
@@ -21,49 +21,39 @@ import (
 	"github.com/deckhouse/sds-elastic/api/v1alpha1"
 )
 
-// Reasons the stage FSM publishes. They are not the shared library's own —
-// dashboards and alerts are keyed on these strings — so they are stated here and
-// handed to it rather than adopted from it.
-const (
-	reasonReady          = "Ready"
-	reasonInProgress     = "InProgress"
-	reasonError          = "Error"
-	reasonWaitingForPrev = "WaitingForPrev"
-)
-
-// stageVocabulary is what both reconcilers report their stages with.
+// ecStages and escStages describe each reconciler's stage order and its own
+// aggregate condition type. Everything else is left at the shared library's
+// defaults, so both reconcilers report stages with the reasons every other
+// storage module reports them with: Reconciled, ReconcileFailed, Pending and
+// WaitingForDependency.
 //
-// SkipMissing is deliberately left off, so a stage carrying no condition
-// aggregates to Unknown and the phase reads Pending. A stage that has never been
-// evaluated is not evidence that the resource is healthy, and answering Ready on
-// a set of verdicts that is not complete is how a resource gets called usable on
-// nobody's word.
+// This module used to publish Ready, Error, InProgress and WaitingForPrev
+// instead. Those were kept when the FSM moved onto the shared type, on the
+// grounds that something outside the module might be keyed on them; nothing is
+// — the module ships no alerts or dashboards, and the strings appear in no
+// chart, CRD or document. What they did do is make an ElasticCluster and, say,
+// an LVMVolumeGroup describe the same situation in two vocabularies.
 //
-// It costs nothing today: every path that flushes the status has written the
-// whole stage set, because advance gates the remaining stages whenever one does
-// not pass. The reading only differs after a stage is added to stageOrder — the
-// resources already in the cluster then report Pending until the controller has
-// reconciled them once, which is the honest answer while the new stage has no
-// verdict.
-var stageVocabulary = conditions.Stages{
-	Passed:     reasonReady,
-	Failed:     reasonError,
-	InProgress: reasonInProgress,
-	Blocked:    reasonWaitingForPrev,
-}
+// Reasons a stage publishes for itself are not affected: a stage that reports
+// WaitingForLVMVolumeGroup names something this module knows about and no
+// shared vocabulary can say, so it stays.
+//
+// SkipMissing is deliberately left at false, so a stage carrying no condition
+// aggregates to Unknown and the phase reads Pending. A stage that has never
+// been evaluated is not evidence that the resource is healthy, and answering
+// Ready on a set of verdicts that is not complete is how a resource gets called
+// usable on nobody's word.
 
-// ecStages and escStages pair that vocabulary with each reconciler's stage
-// order and its own aggregate condition type.
 func ecStages() conditions.Stages {
-	s := stageVocabulary
-	s.Types = stageOrder
-	s.ReadyType = v1alpha1.ECConditionReady
-	return s
+	return conditions.Stages{
+		Types:     stageOrder,
+		ReadyType: v1alpha1.ECConditionReady,
+	}
 }
 
 func escStages() conditions.Stages {
-	s := stageVocabulary
-	s.Types = escStageOrder
-	s.ReadyType = v1alpha1.ESCConditionReady
-	return s
+	return conditions.Stages{
+		Types:     escStageOrder,
+		ReadyType: v1alpha1.ESCConditionReady,
+	}
 }


### PR DESCRIPTION
## Description

The stage FSM published its condition reasons as `Ready`, `Error`, `InProgress` and `WaitingForPrev`. Every other storage module publishes `Reconciled`, `ReconcileFailed`, `Pending` and `WaitingForDependency` — the defaults of `conditions.Stages` in sds-common-lib. This drops the four overrides, so both reconcilers report stages with the shared vocabulary.

`stages.go` now declares only what belongs to this module: each reconciler's stage order and its own aggregate condition type.

Two further changes come with it:

- The aggregate `Ready` condition was written with a bare `"Ready"` literal in both reconcilers rather than through the constant, so it would have kept the old reason while the stages moved off it. It now goes through `conditions.ReasonReconciled`.
- Doc comments that named the old reasons are updated. The one describing a past `UpgradeInProgress` bug is reworded to name the gate rather than a specific string, since the point it makes is not about the vocabulary.

Reasons a stage publishes for itself are untouched. `WaitingForLVMVolumeGroup`, `WaitingForBlockDevices`, `BoundVolumesExist` and their siblings name something only this module knows about, and no shared vocabulary can say it.

Stacked on #76; the diff against `main` will contain that PR's commits until it merges.

## Why do we need it, and what problem does it solve?

An `ElasticCluster` and an `LVMVolumeGroup` blocked on a dependency described the same situation in two different words. Anything reading across modules — an operator at a terminal, a support script, a future alert — had to know which module it was looking at before it could read the reason.

The four overrides were kept when the FSM moved onto `conditions.Stages`, on the stated grounds that dashboards or alerts might be keyed on them. That turns out not to be the case: the module ships no alerts and no dashboards, and the strings appear in no chart, CRD, or document. The CRDs and `docs/USAGE.md` enumerate *phases* and *condition types*, neither of which this PR changes. So the compatibility argument that justified keeping them has no subject.

## What is the expected result?

`kubectl get elasticcluster -o yaml` reports stage conditions with `reason: Reconciled` on a healthy cluster, `ReconcileFailed` on a stage that errored, `Pending` on a stage still working, and `WaitingForDependency` on the stages gated behind it. The same for `ElasticStorageClass`.

What MUST NOT change:

- `status.phase` — the phase strings are their own constants (`Pending`, `InProgress`, `Ready`, `Error`) and are unaffected. `Stages.Phase` keys the `Error` phase off the vocabulary it is handed, so it follows the rename without being renamed.
- The printer columns, the condition types, and the per-stage reasons listed above.
- `lastTransitionTime` on any condition. `meta.SetStatusCondition` moves it only on a status transition, and no condition changes status here — the first reconcile after the upgrade rewrites the reason in place.

Existing resources keep the old reasons until the controller reconciles them once, which happens on the first pass after the rollout.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
