### PR TITLE
feat(webhooks): allow sds-object controller to manage Rook object-store CRs

### DIFF
--- a/images/webhooks/handlers/vendorCRValidator.go
+++ b/images/webhooks/handlers/vendorCRValidator.go
@@ -33,6 +33,10 @@ const (
 
 	allowedControllerUser = "system:serviceaccount:d8-sds-elastic:controller"
 	allowedOperatorUser   = "system:serviceaccount:d8-sds-elastic:rook-ceph-system"
+	// allowedObjectUser is the sds-object controller, which manages
+	// CephObjectStore / CephObjectStoreUser for its Heavy profile (S3 / RGW)
+	// on top of an sds-elastic cluster.
+	allowedObjectUser = "system:serviceaccount:d8-sds-object:controller"
 
 	vendorCRDenyMessage = "Direct modifications to Rook Ceph resources are not allowed. " +
 		"Please use ElasticCluster / ElasticStorageClass (storage.deckhouse.io/v1alpha1) to manage the cluster."
@@ -50,7 +54,7 @@ const (
 // not vendor the objectbucket.io CRDs, so there is nothing to guard.
 var vendorAPIGroups = []string{"internal.sdselastic.deckhouse.io"}
 
-var allowedUsers = []string{allowedControllerUser, allowedOperatorUser}
+var allowedUsers = []string{allowedControllerUser, allowedOperatorUser, allowedObjectUser}
 
 func VendorCRValidate(_ context.Context, arReview *model.AdmissionReview, obj metav1.Object) (*kwhvalidating.ValidatorResult, error) {
 	u, ok := obj.(*unstructured.Unstructured)


### PR DESCRIPTION
## Description

This PR targets the `release-0.0` branch, which was cut from the `v0.0.1` tag to
carry fixes on top of the released 0.0.x code base.

It contains a single cherry-pick of `dd983d5` from `main`
("feat(webhooks): allow sds-object controller to manage Rook object-store CRs", #40):
`system:serviceaccount:d8-sds-object:controller` is added to the `allowedUsers`
allowlist of the `vendor-cr-validation` webhook
(`images/webhooks/handlers/vendorCRValidator.go`). No other files are touched.

## Why do we need it, and what problem does it solve?

The `vendor-cr-validation` webhook denies every ServiceAccount except sds-elastic's
own controller and the Rook operator from creating or modifying the vendored Rook
CRs (`internal.sdselastic.deckhouse.io`).

The sds-object module's Heavy profile provisions a Ceph RGW (S3) on top of an
sds-elastic cluster by creating `CephObjectStore` / `CephObjectStoreUser` in
`d8-sds-elastic`, so its controller SA was blocked by the webhook and the profile
could not be deployed.

The fix is already on `main`; this PR brings it to the 0.0.x release line.

## What is the expected result?

With the sds-object module enabled alongside sds-elastic:

- `CephObjectStore` / `CephObjectStoreUser` created by
  `system:serviceaccount:d8-sds-object:controller` in `d8-sds-elastic` MUST be
  admitted by the webhook.
- Any other ServiceAccount or user MUST still be denied with the existing
  `vendorCRDenyMessage`.
- Direct user modifications of the vendored Rook CRs MUST remain denied.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
