### PR TITLE
chore: bump base-images to v2.0.0, ceph 19.2.5 and 20.2.3

### DIFF
--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -10,7 +10,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v1.3.25"
+  BASE_IMAGES_VERSION: "v2.0.0"
 on:
   #pull_request:
   # call from trivy_image_check.yaml, which in turn call from pull_request

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -11,7 +11,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v1.3.25"
+  BASE_IMAGES_VERSION: "v2.0.0"
 on:
   push:
     tags:

--- a/.werf/werf-base-for-vex.yaml
+++ b/.werf/werf-base-for-vex.yaml
@@ -2,6 +2,11 @@
 image: base/vex
 from: {{ index $.Images "builder/distroless" }}
 final: false
+# No ca-certificates here: base-images v2.0.0 dropped it from the pm package
+# index because builder/distroless already ships the bundle (/etc/ssl/cert.pem
+# and /etc/ssl/certs/ca-certificates.crt, byte-identical to the standalone
+# package). Re-adding it to `pm install` fails the build with "no suitable
+# packet found for ca-certificates".
 shell:
   install:
-    - pm install coreutils ca-certificates cosign=2.6.3 jq curl bash
+    - pm install coreutils cosign=2.6.3 jq curl bash

--- a/api/v1alpha1/elastic_cluster.go
+++ b/api/v1alpha1/elastic_cluster.go
@@ -344,7 +344,7 @@ type DaemonStatus struct {
 // DaemonVersionCount is a single (version, count) entry of the
 // CephCluster.status.ceph.versions.<kind> histogram. The Version is
 // the full Ceph version string Rook publishes verbatim, for example
-// "ceph version 19.2.3 (...) squid (stable)".
+// "ceph version 19.2.5 (...) squid (stable)".
 //
 // +k8s:deepcopy-gen=true
 type DaemonVersionCount struct {
@@ -530,15 +530,15 @@ const ElasticClusterKind = "ElasticCluster"
 // Supported Ceph container image tags built by the sds-elastic module
 // (images/ceph/werf.inc.yaml, one variant per tag).
 const (
-	CephVersionV1923 = "v19.2.3"
-	CephVersionV2022 = "v20.2.2"
+	CephVersionV1925 = "v19.2.5"
+	CephVersionV2023 = "v20.2.3"
 )
 
 // DefaultCephVersion is used when spec.cephVersion is omitted.
-const DefaultCephVersion = CephVersionV1923
+const DefaultCephVersion = CephVersionV1925
 
 // SupportedCephVersions lists every allowed spec.cephVersion value.
-var SupportedCephVersions = []string{CephVersionV1923, CephVersionV2022}
+var SupportedCephVersions = []string{CephVersionV1925, CephVersionV2023}
 
 // Status.phase values shared across ElasticCluster and ElasticStorageClass.
 const (

--- a/crds/doc-ru-elasticcluster.yaml
+++ b/crds/doc-ru-elasticcluster.yaml
@@ -212,7 +212,7 @@ spec:
                           version:
                             description: |
                               Строка версии Ceph, которую публикует Rook (как есть, например
-                              `ceph version 19.2.3 (...) squid (stable)`).
+                              `ceph version 19.2.5 (...) squid (stable)`).
                           count:
                             description: Сколько OSD-демонов сообщили эту версию.
                 mons:

--- a/crds/elasticcluster.yaml
+++ b/crds/elasticcluster.yaml
@@ -382,7 +382,7 @@ spec:
                             type: string
                             description: |
                               Ceph version string Rook publishes for this bucket
-                              (verbatim — e.g. `ceph version 19.2.3 (...) squid (stable)`).
+                              (verbatim — e.g. `ceph version 19.2.5 (...) squid (stable)`).
                           count:
                             type: integer
                             format: int32

--- a/images/ceph/werf.inc.yaml
+++ b/images/ceph/werf.inc.yaml
@@ -5,16 +5,16 @@
   built in .werf/images.yaml from oss.yaml. For each entry produces one werf
   image named "<ImageName>-<condition value, dots->dashes>", e.g.:
 
-    ceph-v19-3-0
-    ceph-v20-2-2
+    ceph-v19-2-5
+    ceph-v20-2-3
 
   The image is assembled from the Deckhouse container-base package catalog with
   `pm` instead of building Ceph from source: the `ceph@<ver>` metapackage pulls
   the mon/osd/mds/mgr/rgw daemons, the client tools (rbd, rados, ceph-fuse,
   mount.ceph, ...) and librbd/librados/libcephfs, and `ceph-volume@<ver>` adds
   the OSD provisioning tool Rook shells out to. Only the versions published in
-  the catalog can be built; oss.yaml pins the stable releases 19.2.3 (squid) and
-  20.2.2 (tentacle). Use a stable ceph_release: a dev build (e.g. 19.3.0) does
+  the catalog can be built; oss.yaml pins the stable releases 19.2.5 (squid) and
+  20.2.3 (tentacle). Use a stable ceph_release: a dev build (e.g. 19.3.0) does
   not complete RADOS ops for a newer stable client, so Rook's `rbd pool init`
   hangs.
 
@@ -31,6 +31,11 @@
 image: {{ $.ModuleNamePrefix }}{{ $.ImageName }}-{{ $tagDash }}
 from: {{ index $.Images "builder/distroless" }}
 
+# No ca-certificates in the pm list below: base-images v2.0.0 dropped it from
+# the pm package index because builder/distroless already ships the bundle
+# (/etc/ssl/cert.pem and /etc/ssl/certs/ca-certificates.crt, byte-identical to
+# the standalone package). Re-adding it fails the build with "no suitable
+# packet found for ca-certificates".
 shell:
   setup:
     - |
@@ -50,7 +55,6 @@ shell:
         coreutils \
         bash \
         jq \
-        ca-certificates \
         libquadmath \
         python-wheel
     # Without the bash package, container-base's /bin/bash is a busybox symlink
@@ -121,7 +125,7 @@ shell:
     # dead code; /usr/bin/ceph-volume is a plain `from ceph_volume.main import
     # Volume` script, and _load_library_extensions() — the one entry-point
     # consumer — resolves through importlib.metadata. Checked both catalog
-    # versions (19.2.3 and 20.2.2) and confirmed by running ceph-volume with an
+    # versions (19.2.5 and 20.2.3) and confirmed by running ceph-volume with an
     # otherwise empty site-packages. Installing it is not free: every setuptools
     # wheel the python-wheel catalog ships reports CVEs against the release
     # (CVE-2024-6345, CVE-2025-47273 on 69.0.3; CVE-2026-59890 on 80.8.0) and,
@@ -159,7 +163,7 @@ shell:
       # reads sqlite3.version.
       python3.12 -c "p='/usr/lib/python3.12/sqlite3/dbapi2.py'; s=open(p).read(); o='from _sqlite3 import _deprecated_version'; n='try:\n    from _sqlite3 import _deprecated_version\nexcept ImportError:\n    _deprecated_version = \"2.6.0\"'; open(p,'w').write(s.replace(o,n,1))"
       python3.12 -c 'import sqlite3; print("sqlite3 OK:", sqlite3.sqlite_version)'
-    # Stable squid 19.2.3 still does `from distutils.util import strtobool` in two
+    # Stable squid 19.2.5 still does `from distutils.util import strtobool` in two
     # mgr modules, but PEP 632 dropped distutils from the python3.12 stdlib; the
     # only thing that puts it back is setuptools' _distutils_hack + the
     # distutils-precedence.pth, which this image deliberately does not ship (see
@@ -171,7 +175,7 @@ shell:
     # leaves "storage filesystem not ready". Inline the six-line strtobool instead
     # of dragging setuptools back in just for it; the shim is byte-compatible with
     # distutils' (same accepted spellings, same ValueError). Tolerant/idempotent:
-    # tentacle 20.2.2 already dropped both imports, so it is a no-op there.
+    # tentacle 20.2.3 already dropped both imports, so it is a no-op there.
     - |
       for p in /usr/share/ceph/mgr/volumes/fs/operations/pin_util.py \
                /usr/share/ceph/mgr/dashboard/tools.py; do
@@ -179,7 +183,7 @@ shell:
         python3.12 -c "import ast; p='$p'; s=open(p).read(); ast.parse(s); assert 'distutils' not in s, p + ' still imports distutils'"
       done
       echo 'mgr modules: no distutils imports left'
-    # ceph-volume in stable squid 19.2.3 is not Python 3.12 compatible: its
+    # ceph-volume in stable squid 19.2.5 is not Python 3.12 compatible: its
     # main.py get_entry_points() does `entry_points().get(group, [])`, but under
     # python3.12 importlib.metadata.entry_points() returns a non-dict EntryPoints
     # (no .get()), so every osd-prepare job crashes with
@@ -192,8 +196,8 @@ shell:
       python3.12 -c "s=open('/usr/lib/python3.12/site-packages/ceph_volume/main.py').read(); import ast; ast.parse(s); assert 'entry_points().get(' not in s, 'ceph_volume main.py still uses py<3.10 entry_points().get()'; print('ceph_volume get_entry_points OK for py3.12')"
     # ceph-mgr loads each python module in its own CPython subinterpreter, but
     # bcrypt is a Rust/PyO3 extension that refuses to load there ("PyO3 modules
-    # do not yet support subinterpreters"). Stable squid 19.2.3's mgr_util.py
-    # imports bcrypt at top level and nearly every mgr module imports mgr_util,
+    # do not yet support subinterpreters"). Older squid mgr_util.py builds
+    # import bcrypt at top level and nearly every mgr module imports mgr_util,
     # so prometheus/volumes/pg_autoscaler/... fail their dependency check and are
     # disabled: with prometheus down Rook cannot read
     # mgr/prometheus/rbd_stats_pools (RBD CephBlockPool stalls), and with volumes
@@ -208,9 +212,9 @@ shell:
     # import pattern is anchored to column 0 ('\nimport bcrypt\n') so a mgr that
     # already ships the guard is left alone: matching the bare substring would
     # hit the indented 'import bcrypt' inside the existing try: and splice a
-    # second, unindented try: block into it (IndentationError). ceph-mgr 19.2.3
-    # from base-images v1.3.20 on ships the guard; tentacle 20.2.2 dropped the
-    # mgr_util bcrypt import entirely, so both are no-ops today.
+    # second, unindented try: block into it (IndentationError). ceph-mgr 19.2.5
+    # ships the guard; tentacle 20.2.3 dropped the mgr_util bcrypt import
+    # entirely, so both are no-ops today.
     - |
       python3.12 -c "p='/usr/share/ceph/mgr/mgr_util.py'; s=open(p).read(); o1='\nimport bcrypt\n'; n1='\ntry:\n    import bcrypt\nexcept Exception:\n    bcrypt = None\n'; o2='    if not password:\n        return None\n    if not salt_password:\n'; n2='    if not password:\n        return None\n    global bcrypt\n    if bcrypt is None:\n        import bcrypt\n    if not salt_password:\n'; s=(s.replace(o1,n1,1) if o1 in s else s); s=(s.replace(o2,n2,1) if o2 in s else s); open(p,'w').write(s)"
       python3.12 -c "import ast; s=open('/usr/share/ceph/mgr/mgr_util.py').read(); ast.parse(s); assert 'import bcrypt' not in s.splitlines(), 'mgr_util.py still has an unguarded top-level import bcrypt'; print('mgr_util.py: no unguarded top-level import bcrypt')"
@@ -279,16 +283,19 @@ shell:
       # Stock ceph packages ship /var/lib/ceph/osd; the pm ceph package does not.
       mkdir -p /var/lib/ceph/osd /var/log/ceph /run/ceph
       chown 167:167 /var/lib/ceph /var/lib/ceph/osd /var/log/ceph /run/ceph
-    # container-base's ceph packages ship UNSTAMPED version constants
+    # container-base's ceph packages used to ship UNSTAMPED version constants
     # (CEPH_GIT_NICE_VER="Development", CEPH_GIT_VER="no_version"), so both
     # `ceph --version` (python CLI) and the C++ daemons (via libceph-common)
-    # report `ceph version Development (no_version) <name> (dev)`. Rook cannot
+    # reported `ceph version Development (no_version) <name> (dev)`. Rook cannot
     # parse that ("failed to extract ceph version: failed to parse version
     # from ...") and the CephCluster reconcile fails its version check. Stamp the
     # real X.Y.Z (from oss.yaml) into the python CLI and into libceph-common's
     # null-terminated version token (length-preserving, so ELF offsets stay
-    # intact). Idempotent: once container-base stamps the version itself the
-    # token is absent and this becomes a no-op (then this block can be removed).
+    # intact). Idempotent, and a no-op on base-images v2.0.0: both 19.2.5 and
+    # 20.2.3 carry the real version in /usr/bin/ceph and in libceph-common.so.2,
+    # so the sed rewrites the constant with the identical value and the ELF token
+    # is already absent. Kept as a guard against a catalog regression; drop it
+    # once stamped packages are the settled contract.
     - |
       CEPH_VER="{{ $verNoPrefix }}"
       if [ -f /usr/bin/ceph ]; then

--- a/images/controller/internal/controller/condition_sanitization_test.go
+++ b/images/controller/internal/controller/condition_sanitization_test.go
@@ -33,7 +33,7 @@ import (
 // Rook/csi-ceph resource kinds and the rook-ceph-mon Secret/ConfigMap are
 // an internal implementation detail kept to the controller logs only.
 // Matched case-insensitively against the lowercased message: Rook emits
-// the full version banner ("ceph version 19.2.3 (...) squid") in
+// the full version banner ("ceph version 19.2.5 (...) squid") in
 // lowercase, so a case-sensitive "Ceph" check would miss it.
 var vendorEntitySubstrings = []string{"ceph", "rook", "rook-ceph-mon", "csi-ceph"}
 
@@ -49,28 +49,28 @@ var _ = Describe("condition message sanitization (no vendor entity leak)", func(
 	ctx := context.Background()
 
 	Describe("EC upgrade probe messages", func() {
-		desiredImage := "registry.example.com/ceph:v19.2.3"
+		desiredImage := "registry.example.com/ceph:v19.2.5"
 		desiredVersion := v1alpha1.DefaultCephVersion
-		otherImage := "registry.example.com/ceph:v20.2.2"
+		otherImage := "registry.example.com/ceph:v20.2.3"
 
 		It("single converged version", func() {
-			cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", "v19.2.3", desiredImage)
+			cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", "v19.2.5", desiredImage)
 			withCephClusterCephStatus(cc, "HEALTH_OK", "", "", 0, 0, 0, "", nil, map[string]map[string]int32{
-				"overall": {cephVerString1930: 9},
+				"overall": {cephVerStringSquid: 9},
 			})
 			expectNoVendorLeak(probeCephUpgradeState(cc, desiredImage, desiredVersion).Msg)
 		})
 
 		It("mixed versions mid-roll", func() {
-			cc := newCephClusterUnstructured(newTestElasticCluster(), "Progressing", "20.2.2-0", otherImage)
+			cc := newCephClusterUnstructured(newTestElasticCluster(), "Progressing", "20.2.3-0", otherImage)
 			withCephClusterCephStatus(cc, "HEALTH_OK", "", "", 0, 0, 0, "", nil, map[string]map[string]int32{
-				"overall": {cephVerString1930: 4, cephVerString2022: 5},
+				"overall": {cephVerStringSquid: 4, cephVerStringTentacle: 5},
 			})
-			expectNoVendorLeak(probeCephUpgradeState(cc, otherImage, "v20.2.2").Msg)
+			expectNoVendorLeak(probeCephUpgradeState(cc, otherImage, "v20.2.3").Msg)
 		})
 
 		It("queued bump on healthy cluster", func() {
-			cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", "v19.2.3", otherImage)
+			cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", "v19.2.5", otherImage)
 			withCephClusterCephStatus(cc, "HEALTH_OK", "", "", 0, 0, 0, "", nil, nil)
 			expectNoVendorLeak(probeCephUpgradeState(cc, desiredImage, desiredVersion).Msg)
 		})

--- a/images/controller/internal/controller/controller_suite_test.go
+++ b/images/controller/internal/controller/controller_suite_test.go
@@ -79,7 +79,7 @@ func newTestLogger() *logger.Logger {
 func newTestCfg() *config.Options {
 	return &config.Options{
 		ControllerNamespace:     "d8-sds-elastic",
-		CephImages:              map[string]string{v1alpha1.DefaultCephVersion: "registry.example.com/ceph:v19.2.3"},
+		CephImages:              map[string]string{v1alpha1.DefaultCephVersion: "registry.example.com/ceph:v19.2.5"},
 		MaxConcurrentReconciles: 1,
 		RequeueInterval:         time.Second,
 	}

--- a/images/controller/internal/controller/elastic_cluster_controller_test.go
+++ b/images/controller/internal/controller/elastic_cluster_controller_test.go
@@ -100,7 +100,7 @@ var _ = Describe("ElasticClusterReconciler.Reconcile", func() {
 				newBlockDevice("bd-a", "node-a", "100Gi", true, nil),
 				newRookMonSecret("fsid-abc", "admin-key", "mon-key"),
 				newRookMonEndpointsCM("a=10.0.0.1:6789", "a"),
-				newCephClusterUnstructured(ec, "Ready", "v19.2.3", cephImage),
+				newCephClusterUnstructured(ec, "Ready", "v19.2.5", cephImage),
 				&v1alpha1.ElasticClusterCredential{
 					ObjectMeta: metav1.ObjectMeta{Name: testECName},
 					Spec:       v1alpha1.ElasticClusterCredentialSpec{AdminSecret: "admin-key"},
@@ -175,7 +175,7 @@ var _ = Describe("ElasticClusterReconciler.Reconcile", func() {
 				newBlockDevice("bd-a", "node-a", "100Gi", true, nil),
 				newRookMonSecret("fsid-abc", "admin-key", "mon-key"),
 				newRookMonEndpointsCM("a=10.0.0.1:6789", "a"),
-				newCephClusterUnstructured(ec, "Ready", "v19.2.3", cephImage),
+				newCephClusterUnstructured(ec, "Ready", "v19.2.5", cephImage),
 				&v1alpha1.ElasticClusterCredential{
 					ObjectMeta: metav1.ObjectMeta{Name: testECName},
 					Spec:       v1alpha1.ElasticClusterCredentialSpec{AdminSecret: "admin-key"},
@@ -278,12 +278,12 @@ var _ = Describe("ElasticClusterReconciler.Reconcile", func() {
 			ec := newTestElasticCluster()
 			cephImage := newTestCfg().CephImages[v1alpha1.DefaultCephVersion]
 
-			cc := newCephClusterUnstructured(ec, "Progressing", "20.2.2-0", cephImage)
+			cc := newCephClusterUnstructured(ec, "Progressing", "20.2.3-0", cephImage)
 			withCephClusterCephStatus(cc, "HEALTH_OK", "", "", 0, 0, 0, "", nil, map[string]map[string]int32{
-				"mon":     {cephVerString2022: 3},
-				"mgr":     {cephVerString2022: 2},
-				"osd":     {cephVerString1930: 4},
-				"overall": {cephVerString1930: 4, cephVerString2022: 5},
+				"mon":     {cephVerStringTentacle: 3},
+				"mgr":     {cephVerStringTentacle: 2},
+				"osd":     {cephVerStringSquid: 4},
+				"overall": {cephVerStringSquid: 4, cephVerStringTentacle: 5},
 			})
 
 			cl := newFakeClient(
@@ -340,7 +340,7 @@ var _ = Describe("ElasticClusterReconciler.Reconcile", func() {
 			// Lagging version on the printcolumn so callers see the
 			// still-rolling daemons' version, not Rook's target marker.
 			Expect(latest.Status.CephVersion).NotTo(BeNil())
-			Expect(latest.Status.CephVersion.Running).To(Equal(cephVerString1930))
+			Expect(latest.Status.CephVersion.Running).To(Equal(cephVerStringSquid))
 			Expect(latest.Status.CephVersion.Requested).To(Equal(v1alpha1.DefaultCephVersion))
 		})
 	})

--- a/images/controller/internal/controller/elastic_cluster_helpers_test.go
+++ b/images/controller/internal/controller/elastic_cluster_helpers_test.go
@@ -49,11 +49,11 @@ var _ = Describe("ElasticCluster pure helpers", func() {
 		func(running, desired string, want bool) {
 			Expect(versionMatches(running, desired)).To(Equal(want))
 		},
-		Entry("exact match", "v19.2.3", "v19.2.3", true),
-		Entry("bare vs prefixed", "19.2.3", "v19.2.3", true),
-		Entry("rook suffix", "ceph version 19.2.3 (abc)", "v19.2.3", true),
-		Entry("boundary: must not match longer patch", "19.2.30", "v19.2.3", false),
-		Entry("mismatch", "18.2.0", "v19.2.3", false),
+		Entry("exact match", "v19.2.5", "v19.2.5", true),
+		Entry("bare vs prefixed", "19.2.5", "v19.2.5", true),
+		Entry("rook suffix", "ceph version 19.2.5 (abc)", "v19.2.5", true),
+		Entry("boundary: must not match longer patch", "19.2.50", "v19.2.5", false),
+		Entry("mismatch", "18.2.0", "v19.2.5", false),
 	)
 
 	DescribeTable("cephHealthOK",

--- a/images/controller/internal/controller/elastic_cluster_observability.go
+++ b/images/controller/internal/controller/elastic_cluster_observability.go
@@ -221,9 +221,9 @@ func parseCephCapacity(cc *unstructured.Unstructured) *v1alpha1.CephCapacityStat
 //	status:
 //	  ceph:
 //	    versions:
-//	      mon: { "ceph version 19.2.3 ...": 3 }
-//	      mgr: { "ceph version 19.2.3 ...": 1 }
-//	      osd: { "ceph version 19.2.3 ...": 6, "ceph version 18.2.0 ...": 3 }
+//	      mon: { "ceph version 19.2.5 ...": 3 }
+//	      mgr: { "ceph version 19.2.5 ...": 1 }
+//	      osd: { "ceph version 19.2.5 ...": 6, "ceph version 18.2.0 ...": 3 }
 //	      overall: { ... }   # ignored — we expose per-kind only
 func parseCephDaemonsByVersion(cephObj map[string]interface{}, kind string) (int32, []v1alpha1.DaemonVersionCount) {
 	versions, ok := cephObj["versions"].(map[string]interface{})

--- a/images/controller/internal/controller/elastic_cluster_observability_test.go
+++ b/images/controller/internal/controller/elastic_cluster_observability_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	cephVerSquid    = "ceph version 19.2.3 (1ac1f3d) squid (stable)"
+	cephVerSquid    = "ceph version 19.2.5 (1ac1f3d) squid (stable)"
 	cephVerReef     = "ceph version 18.2.0 (5dd24139) reef (stable)"
 	cephVerQuincyA  = "ceph version 17.2.7 (b12291d) quincy (stable)"
 	cephVerQuincyAA = "ceph version 17.2.6 (d7ff0d10) quincy (stable)"
@@ -46,7 +46,7 @@ var _ = Describe("populateObservability", func() {
 
 	Context("CephCluster carries a fully-populated status.ceph", func() {
 		It("lifts health, Quantity capacity, check details, and per-daemon byVersion onto the EC.status builder", func() {
-			cc := newCephClusterUnstructured(ec, "Ready", "v19.2.3", "registry.example.com/ceph:v19.2.3")
+			cc := newCephClusterUnstructured(ec, "Ready", "v19.2.5", "registry.example.com/ceph:v19.2.5")
 			withCephClusterCephStatus(cc,
 				"HEALTH_WARN",
 				"1 mon down",
@@ -130,7 +130,7 @@ var _ = Describe("populateObservability", func() {
 
 	Context("partially observed CephCluster (no capacity, no versions yet)", func() {
 		It("publishes health-only without forcing a synthetic zero capacity or empty version blocks", func() {
-			cc := newCephClusterUnstructured(ec, "Progressing", "", "registry.example.com/ceph:v19.2.3")
+			cc := newCephClusterUnstructured(ec, "Progressing", "", "registry.example.com/ceph:v19.2.5")
 			withCephClusterCephStatus(cc, "HEALTH_OK", "", "", 0, 0, 0, "", nil, nil)
 			cl := newFakeClient(ec, cc)
 			r := newElasticClusterReconciler(cl)
@@ -151,7 +151,7 @@ var _ = Describe("populateObservability", func() {
 
 	Context("CephCluster.status.ceph.versions block missing for some daemon kinds", func() {
 		It("publishes only the kinds Ceph actually reported", func() {
-			cc := newCephClusterUnstructured(ec, "Ready", "v19.2.3", "registry.example.com/ceph:v19.2.3")
+			cc := newCephClusterUnstructured(ec, "Ready", "v19.2.5", "registry.example.com/ceph:v19.2.5")
 			withCephClusterCephStatus(cc,
 				"HEALTH_OK", "", "2026-05-25T10:00:00Z",
 				0, 0, 0, "", nil,
@@ -294,7 +294,7 @@ var _ = Describe("ElasticClusterReconciler.Reconcile observability surface", fun
 		ctx := context.Background()
 		ec := newTestElasticCluster()
 
-		cc := newCephClusterUnstructured(ec, "Progressing", "", "registry.example.com/ceph:v19.2.3")
+		cc := newCephClusterUnstructured(ec, "Progressing", "", "registry.example.com/ceph:v19.2.5")
 		withCephClusterCephStatus(cc,
 			"HEALTH_OK", "", "2026-05-25T10:00:00Z",
 			900*1024*1024*1024, 100*1024*1024*1024, 800*1024*1024*1024,

--- a/images/controller/internal/controller/elastic_cluster_upgrade.go
+++ b/images/controller/internal/controller/elastic_cluster_upgrade.go
@@ -261,8 +261,8 @@ func overallVersions(cc *unstructured.Unstructured) map[string]int64 {
 // OSDs), not Rook's already-bumped target marker.
 //
 // "Oldest" is determined lexicographically over the full version
-// strings Rook publishes ("ceph version 19.2.3 (...)" sorts before
-// "ceph version 20.2.2 (...)"). Lexicographic ordering is correct as
+// strings Rook publishes ("ceph version 19.2.5 (...)" sorts before
+// "ceph version 20.2.3 (...)"). Lexicographic ordering is correct as
 // long as the major/minor segments stay zero-padded relative to each
 // other, which is true for every Ceph release in the supported range.
 //
@@ -283,7 +283,7 @@ func pickRunningVersion(overall map[string]int64, runningFromVersionField string
 
 // formatVersionsHistogram renders a versions.overall map into a stable,
 // human-readable summary for the UpgradeInProgress condition message.
-// Output example: `19.2.3 4 → 20.2.2 5`. Sorted by version asc so the
+// Output example: `19.2.5 4 → 20.2.3 5`. Sorted by version asc so the
 // oldest (lagging) version appears first.
 func formatVersionsHistogram(overall map[string]int64) string {
 	keys := make([]string, 0, len(overall))
@@ -331,7 +331,7 @@ func cephHealthOK(h string) bool {
 // when both refer to the same release.
 //
 // strings.Contains alone is not safe for a pure substring match: it
-// would falsely accept "19.2.30" when desired is "v19.2.3". The check
+// would falsely accept "19.2.50" when desired is "v19.2.5". The check
 // below requires that the desired version is followed in the running
 // string either by end-of-string or by a non-digit character (".",
 // "-", " ", "(", etc.), which Rook always emits.

--- a/images/controller/internal/controller/elastic_cluster_upgrade_test.go
+++ b/images/controller/internal/controller/elastic_cluster_upgrade_test.go
@@ -30,53 +30,53 @@ const (
 	// Full ceph version strings exactly as Rook publishes them under
 	// status.ceph.versions.<kind>. Keys must include the major.minor.patch
 	// segment that versionMatches looks for.
-	cephVerString1930 = "ceph version 19.2.3 (c92aebb279828e9c3c1f5d24613efca272649e62) squid (stable)"
-	cephVerString2022 = "ceph version 20.2.2 (6a49aff47758778a5f5951e731d437c317f72fb2) tentacle (stable)"
+	cephVerStringSquid    = "ceph version 19.2.5 (abc7aa7f2701e5d46878fd5e6bb7e2955f1a395a) squid (stable)"
+	cephVerStringTentacle = "ceph version 20.2.3 (06c2f9c35b67055a8a6fb99d1be236b3c4832ace) tentacle (stable)"
 )
 
 var _ = Describe("probeCephUpgradeState", func() {
-	desiredVersion := v1alpha1.DefaultCephVersion // "v19.2.3"
+	desiredVersion := v1alpha1.DefaultCephVersion // "v19.2.5"
 	desiredImage := newTestCfg().CephImages[v1alpha1.DefaultCephVersion]
-	otherImage := "registry.example.com/ceph:v20.2.2"
+	otherImage := "registry.example.com/ceph:v20.2.3"
 
 	It("returns Done when versions.overall has a single key matching desired", func() {
-		cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", "v19.2.3", desiredImage)
+		cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", "v19.2.5", desiredImage)
 		withCephClusterCephStatus(cc, "HEALTH_OK", "", "", 0, 0, 0, "", nil, map[string]map[string]int32{
-			"overall": {cephVerString1930: 9},
+			"overall": {cephVerStringSquid: 9},
 		})
 
 		probe := probeCephUpgradeState(cc, desiredImage, desiredVersion)
 
 		Expect(probe.Done).To(BeTrue())
 		Expect(probe.InProgress).To(BeFalse())
-		Expect(probe.Running).To(Equal(cephVerString1930))
+		Expect(probe.Running).To(Equal(cephVerStringSquid))
 		Expect(probe.Msg).To(ContainSubstring("running version"))
 	})
 
 	It("returns InProgress with mixed versions.overall (mid-roll)", func() {
 		// Faithful reproduction of the user-reported snapshot: image
-		// has been bumped to v20.2.2, mon/mgr already on the new
+		// has been bumped to v20.2.3, mon/mgr already on the new
 		// version, OSDs still on the old one — versions.overall is
 		// multi-key. Probe must say InProgress=True even though
 		// status.version.version Rook publishes is the new version.
-		cc := newCephClusterUnstructured(newTestElasticCluster(), "Progressing", "20.2.2-0", otherImage)
+		cc := newCephClusterUnstructured(newTestElasticCluster(), "Progressing", "20.2.3-0", otherImage)
 		withCephClusterCephStatus(cc, "HEALTH_OK", "", "", 0, 0, 0, "", nil, map[string]map[string]int32{
-			"mon":     {cephVerString2022: 3},
-			"mgr":     {cephVerString2022: 2},
-			"osd":     {cephVerString1930: 4},
-			"overall": {cephVerString1930: 4, cephVerString2022: 5},
+			"mon":     {cephVerStringTentacle: 3},
+			"mgr":     {cephVerStringTentacle: 2},
+			"osd":     {cephVerStringSquid: 4},
+			"overall": {cephVerStringSquid: 4, cephVerStringTentacle: 5},
 		})
 
-		probe := probeCephUpgradeState(cc, otherImage, "v20.2.2")
+		probe := probeCephUpgradeState(cc, otherImage, "v20.2.3")
 
 		Expect(probe.Done).To(BeFalse())
 		Expect(probe.InProgress).To(BeTrue())
 		// Lagging version surfaced on the printcolumn so callers
 		// see the still-rolling daemons' version, not Rook's marker.
-		Expect(probe.Running).To(Equal(cephVerString1930))
+		Expect(probe.Running).To(Equal(cephVerStringSquid))
 		Expect(probe.Msg).To(ContainSubstring("rolling update in progress"))
-		Expect(probe.Msg).To(ContainSubstring("19.2.3"))
-		Expect(probe.Msg).To(ContainSubstring("20.2.2"))
+		Expect(probe.Msg).To(ContainSubstring("19.2.5"))
+		Expect(probe.Msg).To(ContainSubstring("20.2.3"))
 	})
 
 	It("returns InProgress when versions.overall has a single key that does not match desired", func() {
@@ -84,21 +84,21 @@ var _ = Describe("probeCephUpgradeState", func() {
 		// bumped (currentImage == desiredImage), but the cluster has
 		// not yet started rolling, so versions.overall still carries
 		// only the old release.
-		cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", "20.2.2-0", otherImage)
+		cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", "20.2.3-0", otherImage)
 		withCephClusterCephStatus(cc, "HEALTH_OK", "", "", 0, 0, 0, "", nil, map[string]map[string]int32{
-			"overall": {cephVerString1930: 9},
+			"overall": {cephVerStringSquid: 9},
 		})
 
-		probe := probeCephUpgradeState(cc, otherImage, "v20.2.2")
+		probe := probeCephUpgradeState(cc, otherImage, "v20.2.3")
 
 		Expect(probe.Done).To(BeFalse())
 		Expect(probe.InProgress).To(BeTrue())
 		Expect(probe.Msg).To(ContainSubstring("running="))
-		Expect(probe.Msg).To(ContainSubstring("desired=v20.2.2"))
+		Expect(probe.Msg).To(ContainSubstring("desired=v20.2.3"))
 	})
 
 	It("returns InProgress when image bump is queued and cluster is healthy", func() {
-		cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", "v19.2.3", otherImage)
+		cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", "v19.2.5", otherImage)
 		withCephClusterCephStatus(cc, "HEALTH_OK", "", "", 0, 0, 0, "", nil, nil)
 
 		probe := probeCephUpgradeState(cc, desiredImage, desiredVersion)
@@ -109,7 +109,7 @@ var _ = Describe("probeCephUpgradeState", func() {
 	})
 
 	It("blocks the bump when image differs and cluster is HEALTH_ERR (pre-upgrade gate)", func() {
-		cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", "v19.2.3", otherImage)
+		cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", "v19.2.5", otherImage)
 		withCephClusterCephStatus(cc, "HEALTH_ERR", "", "", 0, 0, 0, "", nil, nil)
 
 		probe := probeCephUpgradeState(cc, desiredImage, desiredVersion)
@@ -122,13 +122,13 @@ var _ = Describe("probeCephUpgradeState", func() {
 	It("falls back to status.version.version when versions.overall is absent", func() {
 		// Bootstrap edge case: Rook has not yet populated
 		// status.ceph.versions, so we have to trust status.version.version.
-		cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", "v19.2.3", desiredImage)
+		cc := newCephClusterUnstructured(newTestElasticCluster(), "Ready", "v19.2.5", desiredImage)
 
 		probe := probeCephUpgradeState(cc, desiredImage, desiredVersion)
 
 		Expect(probe.Done).To(BeTrue())
 		Expect(probe.InProgress).To(BeFalse())
-		Expect(probe.Running).To(Equal("v19.2.3"))
+		Expect(probe.Running).To(Equal("v19.2.5"))
 	})
 
 	It("falls back to InProgress when versions.overall is absent and version field mismatches", func() {
@@ -175,9 +175,9 @@ var _ = Describe("ensureUpgrade", func() {
 
 	It("returns done when versions.overall converges on desired", func() {
 		cephImage := newTestCfg().CephImages[v1alpha1.DefaultCephVersion]
-		cc := newCephClusterUnstructured(ec, "Ready", "v19.2.3", cephImage)
+		cc := newCephClusterUnstructured(ec, "Ready", "v19.2.5", cephImage)
 		withCephClusterCephStatus(cc, "HEALTH_OK", "", "", 0, 0, 0, "", nil, map[string]map[string]int32{
-			"overall": {cephVerString1930: 9},
+			"overall": {cephVerStringSquid: 9},
 		})
 		cl := newFakeClient(cc)
 		r = newElasticClusterReconciler(cl)
@@ -187,15 +187,15 @@ var _ = Describe("ensureUpgrade", func() {
 		Expect(done).To(BeTrue())
 		Expect(inProgress).To(BeFalse())
 		Expect(msg).To(ContainSubstring("running version"))
-		Expect(status.cephVersion.Running).To(Equal(cephVerString1930))
+		Expect(status.cephVersion.Running).To(Equal(cephVerStringSquid))
 		Expect(status.cephVersion.Requested).To(Equal(v1alpha1.DefaultCephVersion))
 	})
 
 	It("returns in-progress when versions.overall is mixed", func() {
 		cephImage := newTestCfg().CephImages[v1alpha1.DefaultCephVersion]
-		cc := newCephClusterUnstructured(ec, "Progressing", "v19.2.3", cephImage)
+		cc := newCephClusterUnstructured(ec, "Progressing", "v19.2.5", cephImage)
 		withCephClusterCephStatus(cc, "HEALTH_OK", "", "", 0, 0, 0, "", nil, map[string]map[string]int32{
-			"overall": {cephVerString1930: 4, cephVerString2022: 5},
+			"overall": {cephVerStringSquid: 4, cephVerStringTentacle: 5},
 		})
 		cl := newFakeClient(cc)
 		r = newElasticClusterReconciler(cl)
@@ -205,7 +205,7 @@ var _ = Describe("ensureUpgrade", func() {
 		Expect(done).To(BeFalse())
 		Expect(inProgress).To(BeTrue())
 		Expect(msg).To(ContainSubstring("rolling update in progress"))
-		Expect(status.cephVersion.Running).To(Equal(cephVerString1930))
+		Expect(status.cephVersion.Running).To(Equal(cephVerStringSquid))
 	})
 
 	It("returns in-progress fallback when versions.overall is absent and running version differs", func() {

--- a/oss.yaml
+++ b/oss.yaml
@@ -14,8 +14,8 @@
   id: ceph
   versions:
     - condition:
-        ceph: ["v19.2.3"]
-      version: v19.2.3
+        ceph: ["v19.2.5"]
+      version: v19.2.5
     - condition:
-        ceph: ["v20.2.2"]
-      version: v20.2.2
+        ceph: ["v20.2.3"]
+      version: v20.2.3

--- a/templates/controller/controller.yaml
+++ b/templates/controller/controller.yaml
@@ -13,8 +13,8 @@
   again here triggers the env-variables-duplicates lint rule.
 */ -}}
 {{- $cephImages := dict }}
-{{- $_ := set $cephImages "v19.2.3" (include "helm_lib_module_image" (list . "cephV1923")) }}
-{{- $_ := set $cephImages "v20.2.2" (include "helm_lib_module_image" (list . "cephV2022")) }}
+{{- $_ := set $cephImages "v19.2.5" (include "helm_lib_module_image" (list . "cephV1925")) }}
+{{- $_ := set $cephImages "v20.2.3" (include "helm_lib_module_image" (list . "cephV2023")) }}
 {{- $config := dict
   "valuesKey" "sdsElastic"
   "onMasterNode" true


### PR DESCRIPTION
## Description

Bumps `BASE_IMAGES_VERSION` from `v1.3.25` to `v2.0.0` in both build workflows and moves the module's two Ceph variants from 19.2.3/20.2.2 to **19.2.5 (squid)** and **20.2.3 (tentacle)**.

The version pins live in `oss.yaml`; everything else is the rename that follows from them:

- `oss.yaml` — the two `versions[].condition.ceph` pins that generate the per-version image variants (`ceph-v19-2-5`, `ceph-v20-2-3`).
- `api/v1alpha1/elastic_cluster.go` — `CephVersionV1923`/`CephVersionV2022` → `CephVersionV1925`/`CephVersionV2023`. `DefaultCephVersion` stays on squid.
- `templates/controller/controller.yaml` — the `CEPH_IMAGES` map keys and the helm image keys `cephV1923`/`cephV2022` → `cephV1925`/`cephV2023`.
- `images/ceph/werf.inc.yaml` — comments only; no build step changed.
- CRD descriptions and controller test fixtures — example version strings.

**Critical component impact:** this rolls the Ceph daemons. On an existing cluster the new desired version propagates to `CephCluster.spec.cephVersion.image`, and Rook performs its usual staged mon → mgr → mds → osd rolling upgrade. The controller already models this (`probeCephUpgradeState`, `status.cephVersion.upgradeProgress`), so an ElasticCluster reports `InProgress` while the upgrade runs rather than flapping to `Error`.

## Why do we need it, and what problem does it solve?

This is not an optional bump. The container-base `v2.0.0` package catalog **removes** the ceph 19.2.3, 19.3.0, 20.2.2 and 21.3.0 packages and publishes only 19.2.5 and 20.2.3. Bumping `BASE_IMAGES_VERSION` without moving the pins would fail the build at `pm install ceph@19.2.3`, and staying on `v1.3.25` keeps the module on base images that no longer receive updates.

Each version-specific workaround in `images/ceph/werf.inc.yaml` was re-checked against the packages actually published in the `v2.0.0` catalog (`crane export` of the `ceph-mgr-*`, `ceph-volume-*`, `ceph-common-*` and `librbd-*` packages) rather than assumed to carry over:

- **Still needed.** Squid 19.2.5 continues to `from distutils.util import strtobool` in `mgr/volumes/fs/operations/pin_util.py` and `mgr/dashboard/tools.py`, and its `ceph_volume/main.py` still calls the py<3.10 `entry_points().get(group, [])`. Both patches stay. Tentacle 20.2.3 has neither, so both remain no-ops there — same split as 19.2.3/20.2.2.
- **Still a no-op.** 19.2.5 `mgr_util.py` already ships the bcrypt subinterpreter guard, and 20.2.3 dropped the bcrypt import entirely.
- **Newly a no-op.** Both packages now carry the real version in `/usr/bin/ceph` (`CEPH_GIT_NICE_VER = "19.2.5"` / `"20.2.3"`) and in `libceph-common.so.2`; the `Development\0` token is gone. The stamping block is kept as a guard against a catalog regression — it rewrites the constant with an identical value and skips the ELF token — and its comment now records this.
- **Unchanged.** python stays at 3.12.12 (same digest), so the offline wheel install and the `pysqlite3-binary` `_sqlite3` substitution are untouched.

Every package the ceph image installs is published in `v2.0.0`, and every base image key the module uses (`builder/distroless`, `builder/golang`, `builder/golang-alt`, `builder/src`, `builder/scratch`, `builder/alpine`, `builder/alpine-svace`, `jq`, `yq`) still exists. `v2.0.0` does drop `base/nginx`, `base/redis`, `base/gotest`, `base/shell-operator` and `builder/golang-artifact-*`, none of which this module references.

## What is the expected result?

- `werf config render` produces the image variants `ceph-v19-2-5` and `ceph-v20-2-3`, installing `ceph@19.2.5`/`ceph-volume@19.2.5` and `ceph@20.2.3`/`ceph-volume@20.2.3`.
- The generated digest env vars are `MODULE_IMAGE_DIGEST_cephV1925` and `MODULE_IMAGE_DIGEST_cephV2023`, matching the new helm image keys — the controller starts and logs both `CephImages[...]` entries instead of failing config load with `missing image reference for version`.
- On a fresh install a new ElasticCluster comes up on 19.2.5 and reaches `Ready`; `status.cephVersion.requested` is `v19.2.5` and `status.cephVersion.running` reports the 19.2.5 banner.
- On an existing cluster the ElasticCluster goes `InProgress` with `status.cephVersion.upgradeProgress` walking the mon/mgr/mds/osd stages, then returns to `Ready` with both fields on `v19.2.5`. No PVC, pool or filesystem is recreated.
- All build-time assertions in the ceph image still pass — in particular `ceph-volume --help`, the `no distutils imports left` check and the `sqlite3 OK` import.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
